### PR TITLE
CM-134: add jsonExt to create/update individual mutation

### DIFF
--- a/individual/gql_mutations.py
+++ b/individual/gql_mutations.py
@@ -15,10 +15,12 @@ class CreateIndividualInputType(OpenIMISMutation.Input):
     first_name = graphene.String(required=True, max_length=255)
     last_name = graphene.String(required=True, max_length=255)
     dob = graphene.Date(required=True)
+    json_ext = graphene.types.json.JSONString(required=False)
 
 
 class UpdateIndividualInputType(CreateIndividualInputType):
     id = graphene.UUID(required=True)
+    json_ext = graphene.types.json.JSONString(required=False)
 
 
 class CreateGroupInputType(OpenIMISMutation.Input):

--- a/individual/gql_mutations.py
+++ b/individual/gql_mutations.py
@@ -20,7 +20,6 @@ class CreateIndividualInputType(OpenIMISMutation.Input):
 
 class UpdateIndividualInputType(CreateIndividualInputType):
     id = graphene.UUID(required=True)
-    json_ext = graphene.types.json.JSONString(required=False)
 
 
 class CreateGroupInputType(OpenIMISMutation.Input):


### PR DESCRIPTION
[CM-134](https://openimis.atlassian.net/browse/CM-134)

[RELATED FE PR
](https://github.com/openimis/openimis-fe-individual_js/pull/25)

Changes:
- Add jsonExt field to create/update mutation for Individuals. While this change may not be directly related to the FE PR, it was necessary to address an error that occurred during editing. I have fixed the issue within the scope of this ticket.

[CM-134]: https://openimis.atlassian.net/browse/CM-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ