### PR TITLE
Feature: individual import allows location and checks user's row-level security

### DIFF
--- a/individual/apps.py
+++ b/individual/apps.py
@@ -27,7 +27,6 @@ DEFAULT_CONFIG = {
     "validation_calculation_uuid": "4362f958-5894-435b-9bda-df6cadf88352",
     "validation_import_valid_items": "individual_validation.import_valid_items",
     "validation_import_group_valid_items": "individual_validation.import_group_valid_items",
-    "unique_class_validation": "DeduplicationIndividualValidationStrategy",
     "validation_upload_valid_items": "individual_validation.upload_valid_items",
     "validation_upload_valid_items_workflow": "individual-upload-valid-items.individual-upload-valid-items",
     "enable_python_workflows": True,
@@ -69,7 +68,6 @@ class IndividualConfig(AppConfig):
     validation_import_valid_items_workflow = None
     validation_import_valid_items = None
     validation_import_group_valid_items = None
-    unique_class_validation = None
 
     enable_python_workflows = None
     enable_maker_checker_logic_import = None

--- a/individual/apps.py
+++ b/individual/apps.py
@@ -41,7 +41,7 @@ DEFAULT_CONFIG = {
         'json_ext.educated_level'
     ],
     "individual_base_fields": [
-        'first_name', 'last_name', 'dob', 'location_name', 'id'
+        'first_name', 'last_name', 'dob', 'location_name', 'location_code', 'id'
     ]
 }
 

--- a/individual/apps.py
+++ b/individual/apps.py
@@ -39,6 +39,9 @@ DEFAULT_CONFIG = {
     "individual_mask_fields": [
         'json_ext.beneficiary_data_source',
         'json_ext.educated_level'
+    ],
+    "individual_base_fields": [
+        'first_name', 'last_name', 'dob', 'location_name', 'id'
     ]
 }
 
@@ -81,6 +84,7 @@ class IndividualConfig(AppConfig):
     enable_maker_checker_for_group_update = None
     individual_mask_fields = None
     individual_masking_enabled = None
+    individual_base_fields = None
 
     def ready(self):
         from core.models import ModuleConfiguration

--- a/individual/management/commands/fake_individuals.py
+++ b/individual/management/commands/fake_individuals.py
@@ -9,6 +9,7 @@ from django.core.management.base import BaseCommand
 from individual.models import GroupIndividual
 from individual.tests.test_helpers import generate_random_string
 from location.models import Location
+from core import filter_validity
 from core.models import User
 
 
@@ -65,7 +66,7 @@ class Command(BaseCommand):
         location_qs = Location.objects
         if user:
             location_qs = Location.get_queryset(location_qs, user)
-        permitted_locations = list(location_qs.filter(type='V'))
+        permitted_locations = list(location_qs.filter(type='V', *filter_validity()))
 
         individuals = []
         num_individuals = 100

--- a/individual/management/commands/fake_individuals.py
+++ b/individual/management/commands/fake_individuals.py
@@ -43,7 +43,8 @@ def generate_fake_individual(group_code, recipient_info, individual_role, locati
         "number_of_elderly": fake.random_int(min=0, max=5),
         "number_of_children": fake.random_int(min=0, max=10),
         "beneficiary_data_source": fake.company(),
-        "location_name": location.name if location else ""
+        "location_name": location.name if location else "",
+        "location_code": location.code if location else "",
     }
 
 

--- a/individual/management/commands/fake_individuals.py
+++ b/individual/management/commands/fake_individuals.py
@@ -6,6 +6,11 @@ import json
 import tempfile
 
 from django.core.management.base import BaseCommand
+from individual.models import GroupIndividual
+from individual.tests.test_helpers import generate_random_string
+from location.models import Location
+from core.models import User
+
 
 fake = Faker()
 
@@ -21,7 +26,7 @@ json_schema = {
     "beneficiary_data_source": {"type": "string"}
 }
 
-def generate_fake_individual(group_code, recipient_info, individual_role):
+def generate_fake_individual(group_code, recipient_info, individual_role, location=None):
     return {
         "first_name": fake.first_name(),
         "last_name": fake.last_name(),
@@ -37,7 +42,8 @@ def generate_fake_individual(group_code, recipient_info, individual_role):
         "chronic_illness": fake.boolean(),
         "number_of_elderly": fake.random_int(min=0, max=5),
         "number_of_children": fake.random_int(min=0, max=10),
-        "beneficiary_data_source": fake.company()
+        "beneficiary_data_source": fake.company(),
+        "location_name": location.name if location else ""
     }
 
 
@@ -45,8 +51,20 @@ def generate_fake_individual(group_code, recipient_info, individual_role):
 class Command(BaseCommand):
     help = "Create test individual csv for uploading"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--username',
+            type=str,
+            help="Specify the username such that their permitted locations are assigned to individuals"
+        )
+
     def handle(self, *args, **options):
-        from individual.models import GroupIndividual
+        username = options.get('username')
+        user = User.objects.filter(username=username).first()
+        location_qs = Location.objects
+        if user:
+            location_qs = Location.get_queryset(location_qs, user)
+        permitted_locations = list(location_qs.filter(type='V'))
 
         individuals = []
         num_individuals = 100
@@ -55,11 +73,15 @@ class Command(BaseCommand):
         # Exclude the head from role choices so that one group only has one head in randomnes
         available_role_choices = [choice for choice in GroupIndividual.Role if choice != GroupIndividual.Role.HEAD]
 
-        for group_code in range(1, num_households+1):
+        for group_index in range(0, num_households):
+            group_code = generate_random_string()
+            assign_location = random.choice([True, False])
+            location = random.choice(permitted_locations) if assign_location else None
+
             for i in range(num_individuals // num_households):
                 recipient_info = 1 if i == 0 else 0
                 individual_role = GroupIndividual.Role.HEAD if i == 0 else random.choice(available_role_choices)
-                individual = generate_fake_individual(group_code, recipient_info, individual_role)
+                individual = generate_fake_individual(group_code, recipient_info, individual_role, location)
                 individuals.append(individual)
 
         with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv', newline='') as tmp_file:

--- a/individual/models.py
+++ b/individual/models.py
@@ -1,11 +1,14 @@
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 
 import core
 from core.models import HistoryModel
 from graphql import ResolveInfo
 from location.models import Location, LocationManager
+
 
 
 class Individual(HistoryModel):
@@ -119,6 +122,16 @@ class Group(HistoryModel):
             )
         return queryset
 
+@receiver(post_save, sender=Group)
+def update_member_individuals_location(sender, instance, **kwargs):
+    with transaction.atomic():
+        # has to save one-by-one instead of bulk update due to track history
+        for individual in Individual.objects.filter(groupindividuals__group=instance):
+            # only update individual location if group location is present,
+            # because individuals import would create a group with empty locaiton which then takes on the location of the head
+            if instance.location_id and individual.location_id != instance.location_id:
+                individual.location_id=instance.location_id
+                individual.save(user=instance.user_updated)
 
 class GroupDataSource(HistoryModel):
     group = models.ForeignKey(Group, models.DO_NOTHING, blank=True, null=True)

--- a/individual/models.py
+++ b/individual/models.py
@@ -167,6 +167,7 @@ class GroupIndividual(HistoryModel):
         service.handle_head_change(self.id, self.role, self.group_id)
         service.handle_primary_recipient_change(self.id, self.recipient_type, self.group_id)
         service.handle_assure_primary_recipient_in_group(self.group, self.recipient_type)
+        service.ensure_location_consistent(self.group, self.individual, self.role)
         service.update_json_ext_for_group(self.group)
 
     def delete(self, *args, **kwargs):

--- a/individual/services.py
+++ b/individual/services.py
@@ -9,6 +9,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db import transaction
 
 from calculation.services import get_calculation_object
+from core import filter_validity
 from core.custom_filters import CustomFilterWizardStorage
 from core.models import User
 from core.services import BaseService
@@ -661,14 +662,14 @@ class IndividualImportService:
         query = Q()
         for _, row in unique_tuples.iterrows():
             query |= Q(name=row['location_name'], code=row['location_code'])
-        locations = Location.objects.filter(type="V").filter(query)
+        locations = Location.objects.filter(type="V", *filter_validity()).filter(query)
         return {(loc.name, loc.code): loc.parent.parent.id for loc in locations}
 
     @staticmethod
     def _query_duplicate_village_name_code():
         return (
             Location.objects
-            .filter(type="V")
+            .filter(type="V", *filter_validity())
             .values('name', 'code')
             .annotate(name_count=Count('id'))
             .filter(name_count__gt=1)

--- a/individual/services.py
+++ b/individual/services.py
@@ -14,7 +14,7 @@ from core.models import User
 from core.services import BaseService
 from core.signals import register_service_signal
 from django.utils.translation import gettext as _
-from django.db.models import Q, OuterRef, Subquery
+from django.db.models import Q, OuterRef, Subquery, Count
 from individual.apps import IndividualConfig
 from individual.models import (
     Individual,
@@ -586,6 +586,7 @@ class IndividualImportService:
         unique_validations,
         loc_name_dist_ids_from_db,
         user_allowed_loc_ids,
+        duplicate_village_names,
     ):
         validated_dataframe = []
         check_location = 'location_name' in chunk.columns
@@ -603,7 +604,14 @@ class IndividualImportService:
                     field_validation['validations'][f'{field}_uniqueness'] = IndividualImportService._handle_uniqueness(row, field, unique_validations)
 
             if 'location_name' in chunk.columns:
-                field_validation['validations']['location_name'] = IndividualImportService._validate_location_permission(row.location_name, loc_name_dist_ids_from_db, user_allowed_loc_ids)
+                field_validation['validations']['location_name'] = (
+                    IndividualImportService._validate_location(
+                        row.location_name,
+                        loc_name_dist_ids_from_db,
+                        user_allowed_loc_ids,
+                        duplicate_village_names,
+                    )
+                )
 
             validated_dataframe.append(field_validation)
 
@@ -626,9 +634,11 @@ class IndividualImportService:
             # Issue a single DB query instead of per row for efficiency
             loc_name_dist_ids_from_db = self._query_location_district_ids(dataframe.location_name)
             user_allowed_loc_ids = LocationManager().get_allowed_ids(self.user)
+            duplicate_village_names = self._query_dupcliate_village_names()
         else:
             loc_name_dist_ids_from_db = None
             user_allowed_loc_ids = None
+            duplicate_village_names = None
 
         # TODO: Use ProcessPoolExecutor after resolving django dependency loading issue
         validated_dataframe = IndividualImportService.process_chunk(
@@ -636,7 +646,8 @@ class IndividualImportService:
             properties,
             unique_validations,
             loc_name_dist_ids_from_db,
-            user_allowed_loc_ids
+            user_allowed_loc_ids,
+            duplicate_village_names,
         )
 
         self.save_validation_error_in_data_source_bulk(validated_dataframe)
@@ -649,7 +660,18 @@ class IndividualImportService:
         return {loc.name: loc.parent.parent.id for loc in locations}
 
     @staticmethod
-    def _validate_location_permission(location_name, loc_name_dist_ids_from_db, user_allowed_loc_ids):
+    def _query_dupcliate_village_names():
+        return (
+            Location.objects
+            .filter(type="V")
+            .values('name')
+            .annotate(name_count=Count('name'))
+            .filter(name_count__gt=1)
+            .values_list('name', flat=True)
+        )
+
+    @staticmethod
+    def _validate_location(location_name, loc_name_dist_ids_from_db, user_allowed_loc_ids, duplicate_village_names):
         result = {
             'field_name': 'location_name',
         }
@@ -660,6 +682,9 @@ class IndividualImportService:
         elif location_name not in loc_name_dist_ids_from_db:
             result['success'] = False
             result['note'] = f"'location_name' value '{location_name}' is not a valid location name. Please check the spelling against the list of locations in the system."
+        elif location_name in duplicate_village_names:
+            result['success'] = False
+            result['note'] = f"'location_name' value '{location_name}' is ambiguous, because there are more than one location with this name found in the system."
         elif loc_name_dist_ids_from_db[location_name] not in user_allowed_loc_ids:
             result['success'] = False
             result['note'] = f"'location_name' value '{location_name}' is outside the current user's location permissions."

--- a/individual/services.py
+++ b/individual/services.py
@@ -471,6 +471,18 @@ class GroupAndGroupIndividualAlignmentService:
             return
         self._assure_primary_recipient_in_group(group)
 
+    def ensure_location_consistent(self, group, individual, role):
+        if group.location_id == individual.location_id:
+            return
+
+        if role == GroupIndividual.Role.HEAD and group.location_id is None:
+            group.location_id = individual.location_id
+            group.save(user=self.user.user)
+        else:
+            individual.location_id = group.location_id
+            individual.save(user=self.user.user)
+
+
     def _assure_primary_recipient_in_group(self, group):
         group_individuals = GroupIndividual.objects.filter(group=group, is_deleted=False)
         primary_exists = group_individuals.filter(recipient_type=GroupIndividual.RecipientType.PRIMARY).exists()

--- a/individual/services.py
+++ b/individual/services.py
@@ -641,7 +641,9 @@ class IndividualImportService:
         result = {
             'field_name': 'location_name',
         }
-        if loc_name_dist_ids_from_db is None and user_allowed_loc_ids is None:
+        if location_name is None or location_name == "":
+            result['success'] = True
+        elif loc_name_dist_ids_from_db is None and user_allowed_loc_ids is None:
             result['success'] = True
         elif location_name not in loc_name_dist_ids_from_db:
             result['success'] = False

--- a/individual/tests/__init__.py
+++ b/individual/tests/__init__.py
@@ -1,4 +1,5 @@
 from .individual_service_test import IndividualServiceTest
+from .individual_import_service_test import IndividualImportServiceTest
 from .group_service_test import GroupServiceTest
 from .group_individual_service_test import GroupIndividualServiceTest
 from .graphql_query_test import IndividualGQLQueryTest

--- a/individual/tests/__init__.py
+++ b/individual/tests/__init__.py
@@ -4,3 +4,4 @@ from .group_individual_service_test import GroupIndividualServiceTest
 from .graphql_query_test import IndividualGQLQueryTest
 from .graphql_mutation_individual_test import IndividualGQLMutationTest
 from .graphql_mutation_group_test import GroupGQLMutationTest
+from .view_test import ViewTest

--- a/individual/tests/__init__.py
+++ b/individual/tests/__init__.py
@@ -5,4 +5,3 @@ from .group_individual_service_test import GroupIndividualServiceTest
 from .graphql_query_test import IndividualGQLQueryTest
 from .graphql_mutation_individual_test import IndividualGQLMutationTest
 from .graphql_mutation_group_test import GroupGQLMutationTest
-from .view_test import ViewTest

--- a/individual/tests/fixtures/individual_upload.csv
+++ b/individual/tests/fixtures/individual_upload.csv
@@ -1,0 +1,7 @@
+first_name,last_name,dob,location_name,individual_role,recipient_info,group_code
+Mia,Foo,1989-01-01,Washington DC,HEAD,1,AA
+Bob,Foo,1988-01-01,Washington DC,SPOUSE,1,AA
+Eric,Foo,2020-01-01,Washington DC,SON,1,AA
+Ann,Foo,2020-01-01,Washington DC,DAUGHTER,1,AA
+Michelle,Bar,1990-01-01,Fairfax,HEAD,0,BB
+

--- a/individual/tests/fixtures/individual_upload.csv
+++ b/individual/tests/fixtures/individual_upload.csv
@@ -2,6 +2,6 @@ first_name,last_name,dob,location_name,individual_role,recipient_info,group_code
 Mia,Foo,1989-01-01,Washington DC,HEAD,1,AA
 Bob,Foo,1988-01-01,Washington DC,SPOUSE,1,AA
 Eric,Foo,2020-01-01,Washington DC,SON,1,AA
-Ann,Foo,2020-01-01,Washington DC,DAUGHTER,1,AA
+Ann,Foo,2020-01-01,Washington D.C.,DAUGHTER,1,AA
 Michelle,Bar,1990-01-01,Fairfax,HEAD,0,BB
 

--- a/individual/tests/fixtures/individual_upload.csv
+++ b/individual/tests/fixtures/individual_upload.csv
@@ -1,8 +1,7 @@
-first_name,last_name,dob,location_name,individual_role,recipient_info,group_code
-Mia,Foo,1989-01-01,Washington DC,HEAD,1,AA
-Bob,Foo,1988-01-01,Washington DC,SPOUSE,1,AA
-Eric,Foo,2020-01-01,Washington DC,SON,1,AA
-Ann,Foo,2020-01-01,Washington D.C.,DAUGHTER,1,AA
-Michelle,Bar,1990-01-01,Fairfax,HEAD,0,BB
-Frank,Baz,1998-01-01,,HEAD,0,CC
-
+first_name,last_name,dob,location_name,location_code,individual_role,recipient_info,group_code
+Mia,Foo,1989-01-01,Washington DC,202,HEAD,1,AA
+Bob,Foo,1988-01-01,Washington DC,202,SPOUSE,1,AA
+Eric,Foo,2020-01-01,Washington DC,202,SON,1,AA
+Ann,Foo,2020-01-01,Washington D.C.,202,DAUGHTER,1,AA
+Michelle,Bar,1990-01-01,Fairfax,703,HEAD,0,BB
+Frank,Baz,1998-01-01,,,HEAD,0,CC

--- a/individual/tests/fixtures/individual_upload.csv
+++ b/individual/tests/fixtures/individual_upload.csv
@@ -4,4 +4,5 @@ Bob,Foo,1988-01-01,Washington DC,SPOUSE,1,AA
 Eric,Foo,2020-01-01,Washington DC,SON,1,AA
 Ann,Foo,2020-01-01,Washington D.C.,DAUGHTER,1,AA
 Michelle,Bar,1990-01-01,Fairfax,HEAD,0,BB
+Frank,Baz,1998-01-01,,HEAD,0,CC
 

--- a/individual/tests/graphql_query_test.py
+++ b/individual/tests/graphql_query_test.py
@@ -1,6 +1,7 @@
 import json
 from individual.tests.test_helpers import (
     create_individual,
+    create_group,
     create_group_with_individual,
     add_individual_to_group,
     IndividualGQLTestCase,
@@ -18,20 +19,14 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
             group_override={'location': cls.village_a},
             individual_override={'location': cls.village_a},
         )
+
         cls.individual_a_no_group = create_individual(
             cls.admin_user.username,
             payload_override={'location': cls.village_a},
         )
-        cls.individual_a_group_no_loc, cls.group_no_loc, _ = create_group_with_individual(
-            cls.admin_user.username,
-            individual_override={'location': cls.village_a},
-        )
 
-        cls.individual_no_loc_group_a = create_individual(cls.admin_user.username)
-        add_individual_to_group(
+        cls.individual_no_loc, cls.group_no_loc, _ = create_group_with_individual(
             cls.admin_user.username,
-            cls.individual_no_loc_group_a,
-            cls.group_a,
         )
 
         cls.individual_no_loc_no_group = create_individual(cls.admin_user.username)
@@ -209,7 +204,7 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
             )
 
         # SP officer A sees only group from their assigned districts and
-        # groups wihtout location
+        # groups without location
         permitted_uuids = [
             self.group_a.uuid,
             self.group_no_loc.uuid,
@@ -233,7 +228,7 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
 
 
         # SP officer B sees only group from their assigned district and
-        # groups wihtout location
+        # groups without location
         permitted_uuids = [
             self.group_b.uuid,
             self.group_no_loc.uuid,
@@ -301,9 +296,8 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
         self.assertTrue(str(self.individual_a.uuid) in individual_uuids)
         self.assertTrue(str(self.individual_b.uuid) in individual_uuids)
         self.assertTrue(str(self.individual_a_no_group.uuid) in individual_uuids)
-        self.assertTrue(str(self.individual_a_group_no_loc.uuid) in individual_uuids)
+        self.assertTrue(str(self.individual_no_loc.uuid) in individual_uuids)
         self.assertTrue(str(self.individual_no_loc_no_group.uuid) in individual_uuids)
-        self.assertTrue(str(self.individual_no_loc_group_a.uuid) in individual_uuids)
 
         # Health Enrollment Officier (role=1) sees nothing
         response = self.query(
@@ -350,7 +344,7 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
         }}'''
 
         # SP officer A sees only individual from their assigned districts
-        # individuals wihtout location, and individuals whose group has no location
+        # individuals without location, and individuals whose group has no location
         response = self.query(
             query_str,
             headers={"HTTP_AUTHORIZATION": f"Bearer {self.dist_a_user_token}"}
@@ -366,12 +360,11 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
         self.assertTrue(str(self.individual_a.uuid) in individual_uuids)
         self.assertFalse(str(self.individual_b.uuid) in individual_uuids)
         self.assertTrue(str(self.individual_a_no_group.uuid) in individual_uuids)
-        self.assertTrue(str(self.individual_a_group_no_loc.uuid) in individual_uuids)
+        self.assertTrue(str(self.individual_no_loc.uuid) in individual_uuids)
         self.assertTrue(str(self.individual_no_loc_no_group.uuid) in individual_uuids)
-        self.assertTrue(str(self.individual_no_loc_group_a.uuid) in individual_uuids)
 
         # SP officer B sees only individual from their assigned district,
-        # individuals wihtout location, and individuals whose group has no location
+        # individuals without location, and individuals whose group has no location
         response = self.query(
             query_str,
             headers={"HTTP_AUTHORIZATION": f"Bearer {self.dist_b_user_token}"}
@@ -387,9 +380,8 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
         self.assertFalse(str(self.individual_a.uuid) in individual_uuids)
         self.assertTrue(str(self.individual_b.uuid) in individual_uuids)
         self.assertFalse(str(self.individual_a_no_group.uuid) in individual_uuids)
-        self.assertTrue(str(self.individual_a_group_no_loc.uuid) in individual_uuids)
+        self.assertTrue(str(self.individual_no_loc.uuid) in individual_uuids)
         self.assertTrue(str(self.individual_no_loc_no_group.uuid) in individual_uuids)
-        self.assertTrue(str(self.individual_no_loc_group_a.uuid) in individual_uuids)
 
 
     def test_individual_query_with_group(self):
@@ -428,7 +420,7 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
             e['node']['uuid'] for e in individual_data['edges']
         )
         self.assertTrue(str(self.individual_a.uuid) in individual_uuids)
-        self.assertTrue(str(self.individual_no_loc_group_a.uuid) in individual_uuids)
+        self.assertFalse(str(self.individual_no_loc.uuid) in individual_uuids)
         self.assertFalse(str(self.individual_b.uuid) in individual_uuids)
         self.assertFalse(str(self.individual_a_no_group.uuid) in individual_uuids)
 
@@ -478,9 +470,8 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
         permitted_uuids = [
             self.individual_a.uuid,
             self.individual_a_no_group.uuid,
-            self.individual_a_group_no_loc.uuid,
+            self.individual_no_loc.uuid,
             self.individual_no_loc_no_group.uuid,
-            self.individual_no_loc_group_a.uuid,
         ]
 
         not_permitted_uuids = [
@@ -501,12 +492,11 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
 
 
         # SP officer B sees only individual from their assigned district,
-        # individuals wihtout location, and individuals whose group has no location
+        # individuals without location, and individuals whose group has no location
         permitted_uuids = [
             self.individual_b.uuid,
-            self.individual_a_group_no_loc.uuid,
             self.individual_no_loc_no_group.uuid,
-            self.individual_no_loc_group_a.uuid,
+            self.individual_no_loc.uuid,
         ]
 
         not_permitted_uuids = [
@@ -574,7 +564,7 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
         response = send_group_individual_query(self.group_a.uuid, self.dist_a_user_token)
         self.assertResponseNoErrors(response)
         content = json.loads(response.content)
-        self.assertEqual(content['data']['groupIndividual']['totalCount'], 2)
+        self.assertEqual(content['data']['groupIndividual']['totalCount'], 1)
 
         group_data = content['data']['groupIndividual']
 
@@ -582,7 +572,6 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
             e['node']['individual']['uuid'] for e in group_data['edges']
         )
         self.assertTrue(str(self.individual_a.uuid) in individual_uuids)
-        self.assertTrue(str(self.individual_no_loc_group_a.uuid) in individual_uuids)
 
         # SP officer A shouldn't see group individuals from other districts
         response = send_group_individual_query(self.group_b.uuid, self.dist_a_user_token)
@@ -654,11 +643,10 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
             )
 
         # SP officer A sees only individuals from their assigned districts and
-        # from groups wihtout location
+        # from groups without location
         permitted_uuids = [
             self.individual_a.uuid,
-            self.individual_a_group_no_loc.uuid,
-            self.individual_no_loc_group_a.uuid,
+            self.individual_no_loc.uuid,
         ]
 
         not_permitted_uuids = [
@@ -681,15 +669,14 @@ class IndividualGQLQueryTest(IndividualGQLTestCase):
             self.assertEqual(content['data']['groupIndividualHistory']['totalCount'], 0)
 
         # SP officer B sees only group from their assigned district and
-        # from groups wihtout location
+        # from groups without location
         permitted_uuids = [
             self.individual_b.uuid,
-            self.individual_a_group_no_loc.uuid,
+            self.individual_no_loc.uuid,
         ]
 
         not_permitted_uuids = [
             self.individual_a.uuid,
-            self.individual_no_loc_group_a.uuid,
         ]
 
         for uuid in permitted_uuids:

--- a/individual/tests/individual_import_service_test.py
+++ b/individual/tests/individual_import_service_test.py
@@ -1,0 +1,87 @@
+import csv
+import os
+from core.test_helpers import LogInHelper
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from individual.services import IndividualImportService
+from individual.models import (
+    IndividualDataSource,
+    IndividualDataSourceUpload,
+    IndividualDataUploadRecords,
+)
+from individual.tests.test_helpers import generate_random_string
+from unittest.mock import MagicMock
+
+
+def count_csv_records(file_path):
+    with open(file_path, mode='r', encoding='utf-8') as file:
+        reader = csv.reader(file)
+        valid_rows = list(
+            row for row in reader 
+            if any(cell.strip() for cell in row)  # Do not count blank lines
+        )
+        return len(valid_rows) - 1  # Exclude the header row
+
+
+class IndividualImportServiceTest(TestCase):
+    user = None
+    service = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user = LogInHelper().get_or_create_user_api()
+        cls.service = IndividualImportService(cls.user)
+
+        cls.csv_file_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'individual_upload.csv')
+        # SimpleUploadedFile requires a bytes-like object so use 'rb' instead of 'r'
+        with open(cls.csv_file_path, 'rb') as f:
+            cls.csv_content = f.read()
+
+
+    def test_import_individuals(self):
+        uploaded_csv_name = f"{generate_random_string(20)}.csv"
+        csv_file = SimpleUploadedFile(
+            uploaded_csv_name,
+            self.csv_content,
+            content_type="text/csv"
+        )
+
+        mock_workflow = self._create_mock_workflow()
+
+        result = self.service.import_individuals(csv_file, mock_workflow, "group_code")
+        self.assertEqual(result['success'], True)
+
+        # Check that an IndividualDataSourceUpload object was saved in the database
+        upload = IndividualDataSourceUpload.objects.get(source_name=uploaded_csv_name)
+        self.assertIsNotNone(upload)
+        self.assertEqual(upload.source_name, uploaded_csv_name)
+        self.assertEqual(upload.source_type, "individual import")
+        self.assertEqual(upload.status, IndividualDataSourceUpload.Status.TRIGGERED)
+
+        self.assertEqual(result['data']['upload_uuid'], upload.uuid)
+
+        # Check that an IndividualDataUploadRecords object was saved in the database
+        data_upload_record = IndividualDataUploadRecords.objects.get(data_upload=upload)
+        self.assertIsNotNone(data_upload_record)
+        self.assertEqual(data_upload_record.workflow, mock_workflow.name)
+        self.assertEqual(data_upload_record.json_ext['group_aggregation_column'], "group_code")
+
+        # Check that an IndividualDataSource objects saved in the database
+        individual_data_sources = IndividualDataSource.objects.filter(upload=upload)
+        num_records = count_csv_records(self.csv_file_path)
+        self.assertEqual(individual_data_sources.count(), num_records)
+
+        # Check that workflow is triggered
+        mock_workflow.run.assert_called_once_with({
+            'user_uuid': str(self.user.id),
+            'upload_uuid': str(upload.uuid),
+        })
+
+
+    def _create_mock_workflow(self):
+        mock_workflow = MagicMock()
+        mock_workflow.name = 'Test Workflow'
+        return mock_workflow
+

--- a/individual/tests/test_group_and_individual_alignment_service.py
+++ b/individual/tests/test_group_and_individual_alignment_service.py
@@ -1,0 +1,102 @@
+from django.test import TestCase
+
+from core.test_helpers import LogInHelper
+from individual.models import Individual, GroupIndividual, Group
+from individual.services import GroupAndGroupIndividualAlignmentService
+from individual.tests.test_helpers import (
+    create_individual,
+    create_group,
+)
+from location.test_helpers import create_test_village
+
+
+class GroupAndGroupIndividualAlignmentServiceTest(TestCase):
+    user = None
+    service = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user = LogInHelper().get_or_create_user_api()
+        cls.username = cls.user.username
+        cls.service = GroupAndGroupIndividualAlignmentService(cls.user)
+
+        cls.loc_a = create_test_village({
+            'name': 'Village A',
+            'code': 'ViaA',
+        })
+
+        cls.loc_b = create_test_village({
+            'name': 'Village B',
+            'code': 'ViaB'
+        })
+
+    def setUp(self):
+        self.group = create_group(self.username)
+        self.individual = create_individual(self.username)
+
+    def assert_group_and_individual_location_equal(self, group_id, individual_id, location_id):
+        group = Group.objects.get(id=group_id)
+        individual = Individual.objects.get(id=individual_id)
+        self.assertEqual(group.location_id, location_id)
+        self.assertEqual(individual.location_id, location_id)
+
+    def test_ensure_location_consistent_for_head(self):
+        role = GroupIndividual.Role.HEAD
+
+        # When group loc = head loc = None, no op
+        self.service.ensure_location_consistent(self.group, self.individual, role)
+        self.assert_group_and_individual_location_equal(
+            self.group.id, self.individual.id, None
+        )
+
+        # When group has no loc, head has loc, group takes location of the head
+        self.individual.location = self.loc_a
+        self.individual.save(user=self.user)
+        self.service.ensure_location_consistent(self.group, self.individual, role)
+        self.assert_group_and_individual_location_equal(
+            self.group.id, self.individual.id, self.loc_a.id
+        )
+
+        # When head has no loc, group has loc, head takes location of the group
+        self.individual.location = None
+        self.individual.save(user=self.user)
+        self.group.location = self.loc_b
+        self.group.save(user=self.user)
+        self.service.ensure_location_consistent(self.group, self.individual, role)
+        self.assert_group_and_individual_location_equal(
+            self.group.id, self.individual.id, self.loc_b.id
+        )
+
+        # When group and head have diff loc, update head to use group loc
+        self.individual.location = self.loc_a
+        self.individual.save(user=self.user)
+        self.service.ensure_location_consistent(self.group, self.individual, role)
+        self.assert_group_and_individual_location_equal(
+            self.group.id, self.individual.id, self.loc_b.id
+        )
+
+    def test_ensure_location_consistent_for_non_head(self):
+        role = None
+
+        # When group loc = non-head loc = None, no op
+        self.service.ensure_location_consistent(self.group, self.individual, role)
+        self.assert_group_and_individual_location_equal(
+            self.group.id, self.individual.id, None
+        )
+
+        # Otherwise individual loc takes group loc
+        self.individual.location = self.loc_a
+        self.individual.save(user=self.user)
+        self.service.ensure_location_consistent(self.group, self.individual, role)
+        self.assert_group_and_individual_location_equal(
+            self.group.id, self.individual.id, None
+        )
+
+        self.group.location = self.loc_b
+        self.group.save(user=self.user)
+        self.service.ensure_location_consistent(self.group, self.individual, role)
+        self.assert_group_and_individual_location_equal(
+            self.group.id, self.individual.id, self.loc_b.id
+        )

--- a/individual/tests/test_utils.py
+++ b/individual/tests/test_utils.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+from individual.models import IndividualDataSource
+from individual.utils import load_dataframe
+import pandas as pd
+import json
+
+class UtilsTest(TestCase):
+
+    def test_load_dataframe_basic(self):
+        sources = [
+            IndividualDataSource(id=1, json_ext={"name": "Alice", "age": 30}),
+            IndividualDataSource(id=2, json_ext={"name": "Bob", "age": 25})
+        ]
+        df = load_dataframe(sources)
+
+        # Verify structure and values
+        self.assertEqual(len(df), 2)
+        self.assertListEqual(df["id"].tolist(), [1, 2])
+        self.assertListEqual(df["name"].tolist(), ["Alice", "Bob"])
+        self.assertListEqual(df["age"].tolist(), [30, 25])
+
+    def test_load_dataframe_empty_input(self):
+        sources = []
+        df = load_dataframe(sources)
+        self.assertTrue(df.empty)
+
+    def test_load_dataframe_blank_values_in_json_ext(self):
+        source_df = pd.DataFrame([{"name": "Alice"}, {"name": ""}, {"name": None}])
+        sources = []
+        for id, row in source_df.iterrows():
+            json_ext = json.loads(row.to_json())
+            sources.append(IndividualDataSource(id=id+1, json_ext=json_ext))
+
+        df = load_dataframe(sources)
+
+        # Verify 'id' is added even when json_ext is incomplete
+        self.assertEqual(len(df), 3)
+        self.assertListEqual(df["id"].tolist(), [1, 2, 3])
+
+        # Check empty values are loaded as expected
+        self.assertIn("name", df.columns)
+        self.assertEqual(df.at[0, "name"], 'Alice')
+        self.assertEqual(df.at[1, "name"], '')
+        self.assertIsNone(df.at[2, "name"])

--- a/individual/tests/test_view.py
+++ b/individual/tests/test_view.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from core.test_helpers import create_test_interactive_user
 
 
-class ViewTest(APITestCase):
+class TestView(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/individual/tests/test_view.py
+++ b/individual/tests/test_view.py
@@ -29,7 +29,7 @@ class TestView(APITestCase):
             response['Content-Disposition']
         )
 
-        expected_base_csv_header = f'first_name,last_name,dob,location_name,id'
+        expected_base_csv_header = f'first_name,last_name,dob,location_name,location_code,id'
         content = b"".join(response.streaming_content).decode('utf-8')
         self.assertTrue(
             expected_base_csv_header in content,

--- a/individual/tests/test_workflows_individual_update.py
+++ b/individual/tests/test_workflows_individual_update.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.test import TestCase
 from core.test_helpers import create_test_interactive_user
 from individual.models import (
@@ -9,6 +10,7 @@ from individual.models import (
 from individual.workflows.base_individual_update import process_update_individuals_workflow
 from individual.tests.test_helpers import create_test_village, create_individual
 from unittest.mock import patch
+from unittest import skipIf
 import uuid
 
 
@@ -92,6 +94,10 @@ class ProcessUpdateIndividualsWorkflowTest(TestCase):
         )
         self.invalid_data_source.save(user=self.user)
 
+    @skipIf(
+        connection.vendor != "postgresql",
+        "Skipping tests due to implementation usage of validate_json_schema, which is a postgres specific extension."
+    )
     @patch('individual.apps.IndividualConfig.enable_maker_checker_for_individual_update', False)
     def test_process_update_individuals_workflow_successful_execution(self):
         process_update_individuals_workflow(self.user_uuid, self.upload_uuid)
@@ -122,6 +128,10 @@ class ProcessUpdateIndividualsWorkflowTest(TestCase):
         individual2_from_db = Individual.objects.get(id=self.individual2.id)
         self.assertNotEqual(individual2_from_db.first_name, self.individual2_updated_first_name)
 
+    @skipIf(
+        connection.vendor != "postgresql",
+        "Skipping tests due to implementation usage of validate_json_schema, which is a postgres specific extension."
+    )
     @patch('individual.apps.IndividualConfig.enable_maker_checker_for_individual_update', False)
     def test_process_update_individuals_workflow_with_all_valid_entries(self):
         # Update invalid entry in IndividualDataSource to valid data

--- a/individual/tests/test_workflows_individual_update.py
+++ b/individual/tests/test_workflows_individual_update.py
@@ -80,6 +80,7 @@ class ProcessUpdateIndividualsWorkflowTest(TestCase):
                 "last_name": "Doe",
                 "dob": "1980-01-01",
                 "location_name": self.village.name,
+                "location_code": self.village.code,
             }
         )
         self.valid_data_source.save(user=self.user)
@@ -139,6 +140,7 @@ class ProcessUpdateIndividualsWorkflowTest(TestCase):
             "ID": str(self.individual2.id),
             "first_name": self.individual2_updated_first_name,
             "location_name": None,
+            "location_code": None,
         }
         self.invalid_data_source.save(user=self.user)
 
@@ -170,6 +172,7 @@ class ProcessUpdateIndividualsWorkflowTest(TestCase):
             "ID": str(self.individual2.id),
             "first_name": "Jane",
             "location_name": None,
+            "location_code": None,
         }
         self.invalid_data_source.save(user=self.user)
 

--- a/individual/tests/test_workflows_individual_upload.py
+++ b/individual/tests/test_workflows_individual_upload.py
@@ -1,0 +1,130 @@
+from django.test import TestCase
+from core.test_helpers import create_test_interactive_user
+from individual.models import (
+    IndividualDataSource,
+    IndividualDataSourceUpload,
+    IndividualDataUploadRecords,
+)
+from individual.workflows.base_individual_upload import process_import_individuals_workflow
+from unittest.mock import patch
+import uuid
+
+
+class ProcessImportIndividualsWorkflowTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Patch validate_dataframe_headers as it is already tested separately
+        cls.patcher = patch(
+            "individual.workflows.utils.BasePythonWorkflowExecutor.validate_dataframe_headers",
+            lambda self: None
+        )
+        cls.patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.patcher.stop()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = create_test_interactive_user(username="admin")
+        self.user_uuid = self.user.id
+
+        self.upload = IndividualDataSourceUpload(
+            source_name='csv',
+            source_type='upload',
+            status="PENDING",
+        )
+        self.upload.save(user=self.user)
+        self.upload_uuid = self.upload.id
+
+        upload_record = IndividualDataUploadRecords(
+            data_upload=self.upload,
+            workflow='my workflow',
+            json_ext={"group_aggregation_column": None}
+        )
+        upload_record.save(user=self.user.user)
+
+        self.valid_data_source = IndividualDataSource(
+            upload_id=self.upload_uuid,
+            json_ext={"first_name": "John", "last_name": "Doe", "dob": "1980-01-01"}
+        )
+        self.valid_data_source.save(user=self.user)
+
+        self.invalid_data_source = IndividualDataSource(
+            upload_id=self.upload_uuid,
+            json_ext={"first_name": "Jane Workflow"}
+        )
+        self.invalid_data_source.save(user=self.user)
+
+    @patch('individual.services.IndividualConfig.enable_maker_checker_for_individual_upload', False)
+    def test_process_import_individuals_workflow_successful_execution(self):
+        process_import_individuals_workflow(self.user_uuid, self.upload_uuid)
+
+        upload = IndividualDataSourceUpload.objects.get(id=self.upload_uuid)
+
+        # Check that the status is 'FAIL' due to missing fields in one entry
+        self.assertEqual(upload.status, "FAIL")
+        self.assertIsNotNone(upload.error)
+        errors = upload.error['errors']
+        self.assertIn("Invalid entries", errors['error'])
+
+        # Check that the correct failing entries are logged in the error field
+        for key in [
+            "failing_entries_last_name", "failing_entries_dob"
+        ]:
+            self.assertIn(key, errors)
+            self.assertIn(str(self.invalid_data_source.id), errors[key])
+            self.assertNotIn(str(self.valid_data_source.id), errors[key])
+
+        # individual_id should not be assigned for any data sources
+        data_entries = IndividualDataSource.objects.filter(upload_id=self.upload_uuid)
+        for entry in data_entries:
+            self.assertIsNone(entry.individual_id)
+
+    @patch('individual.services.IndividualConfig.enable_maker_checker_for_individual_upload', False)
+    def test_process_import_individuals_workflow_with_all_valid_entries(self):
+        # Update invalid entry in IndividualDataSource to valid data
+        IndividualDataSource.objects.filter(
+                upload_id=self.upload_uuid, json_ext={"first_name": "Jane Workflow"}
+        ).update(
+            json_ext={
+                "first_name": "Jane Workflow", "last_name": "Doe", "dob": "1982-01-01"
+            }
+        )
+
+        process_import_individuals_workflow(self.user_uuid, self.upload_uuid)
+
+        upload = IndividualDataSourceUpload.objects.get(id=self.upload_uuid)
+
+        self.assertEqual(upload.status, "SUCCESS")
+        self.assertEqual(upload.error, {})
+
+        # Verify that individual IDs have been assigned to data entries in IndividualDataSource
+        data_entries = IndividualDataSource.objects.filter(upload_id=self.upload_uuid)
+        for entry in data_entries:
+            self.assertIsNotNone(entry.individual_id)
+
+    @patch('individual.services.IndividualConfig.enable_maker_checker_for_individual_upload', True)
+    def test_process_import_individuals_workflow_with_all_valid_entries_with_maker_checker(self):
+        # Update invalid entry in IndividualDataSource to valid data
+        IndividualDataSource.objects.filter(
+                upload_id=self.upload_uuid, json_ext={"first_name": "Jane Workflow"}
+        ).update(
+            json_ext={
+                "first_name": "Jane Workflow", "last_name": "Doe", "dob": "1982-01-01"
+            }
+        )
+
+        process_import_individuals_workflow(self.user_uuid, self.upload_uuid)
+
+        upload = IndividualDataSourceUpload.objects.get(id=self.upload_uuid)
+
+        self.assertEqual(upload.status, "WAITING_FOR_VERIFICATION")
+        self.assertEqual(upload.error, {})
+
+        # Verify that individual IDs not yet assigned to data entries in IndividualDataSource
+        data_entries = IndividualDataSource.objects.filter(upload_id=self.upload_uuid)
+        for entry in data_entries:
+            self.assertIsNone(entry.individual_id)

--- a/individual/tests/test_workflows_individual_upload.py
+++ b/individual/tests/test_workflows_individual_upload.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.test import TestCase
 from core.test_helpers import create_test_interactive_user
 from individual.models import (
@@ -12,8 +13,13 @@ from individual.models import (
 from individual.workflows.base_individual_upload import process_import_individuals_workflow
 from individual.tests.test_helpers import create_test_village
 from unittest.mock import patch
+from unittest import skipIf
 
 
+@skipIf(
+    connection.vendor != "postgresql",
+    "Skipping tests due to implementation usage of validate_json_schema, which is a postgres specific extension."
+)
 class ProcessImportIndividualsWorkflowTest(TestCase):
 
     @classmethod

--- a/individual/tests/test_workflows_individual_upload.py
+++ b/individual/tests/test_workflows_individual_upload.py
@@ -71,6 +71,7 @@ class ProcessImportIndividualsWorkflowTest(TestCase):
                 "last_name": "Doe",
                 "dob": "1980-01-01",
                 "location_name": self.village.name,
+                "location_code": self.village.code,
             }
         )
         self.valid_data_source.save(user=self.user)
@@ -117,6 +118,7 @@ class ProcessImportIndividualsWorkflowTest(TestCase):
             "last_name": "Doe",
             "dob": "1982-01-01",
             "location_name": None,
+            "location_code": None,
         }
         self.invalid_data_source.save(user=self.user)
 

--- a/individual/tests/test_workflows_individual_upload.py
+++ b/individual/tests/test_workflows_individual_upload.py
@@ -1,9 +1,13 @@
 from django.test import TestCase
 from core.test_helpers import create_test_interactive_user
 from individual.models import (
+    Individual,
     IndividualDataSource,
     IndividualDataSourceUpload,
     IndividualDataUploadRecords,
+    Group,
+    GroupDataSource,
+    GroupIndividual,
 )
 from individual.workflows.base_individual_upload import process_import_individuals_workflow
 from individual.tests.test_helpers import create_test_village
@@ -99,6 +103,7 @@ class ProcessImportIndividualsWorkflowTest(TestCase):
             self.assertIsNone(entry.individual_id)
 
     @patch('individual.apps.IndividualConfig.enable_maker_checker_for_individual_upload', False)
+    @patch('individual.apps.IndividualConfig.enable_maker_checker_for_group_upload', False)
     def test_process_import_individuals_workflow_with_all_valid_entries(self):
         # Update invalid entry in IndividualDataSource to valid data
         self.invalid_data_source.json_ext={
@@ -108,6 +113,11 @@ class ProcessImportIndividualsWorkflowTest(TestCase):
             "location_name": None,
         }
         self.invalid_data_source.save(user=self.user)
+
+        # Update valid entry with a group
+        self.valid_data_source.json_ext['group_code'] = 'HH2'
+        self.valid_data_source.json_ext['individual_role'] = 'HEAD'
+        self.valid_data_source.save(user=self.user)
 
         process_import_individuals_workflow(self.user_uuid, self.upload_uuid)
 
@@ -120,6 +130,34 @@ class ProcessImportIndividualsWorkflowTest(TestCase):
         data_entries = IndividualDataSource.objects.filter(upload_id=self.upload_uuid)
         for entry in data_entries:
             self.assertIsNotNone(entry.individual_id)
+
+        # Check created individuals have the expected field values
+        valid_ds = data_entries.get(id=self.valid_data_source.id)
+        individual1 = Individual.objects.get(id=valid_ds.individual_id)
+        json_ext1 = self.valid_data_source.json_ext
+        self.assertEqual(individual1.first_name, json_ext1['first_name'])
+        self.assertEqual(individual1.last_name, json_ext1['last_name'])
+        self.assertEqual(individual1.dob.strftime('%Y-%m-%d'), json_ext1['dob'])
+        self.assertEqual(individual1.location.name, json_ext1['location_name'])
+
+        invalid_ds = data_entries.get(id=self.invalid_data_source.id)
+        individual2 = Individual.objects.get(id=invalid_ds.individual_id)
+        json_ext2 = self.invalid_data_source.json_ext
+        self.assertEqual(individual2.first_name, json_ext2['first_name'])
+        self.assertEqual(individual2.last_name, json_ext2['last_name'])
+        self.assertEqual(individual2.dob.strftime('%Y-%m-%d'), json_ext2['dob'])
+        self.assertIsNone(individual2.location)
+
+        # Check the individual's group is created and location assigned
+        group_entries = GroupDataSource.objects.filter(upload_id=self.upload_uuid)
+        self.assertEqual(group_entries.count(), 1)
+        group_id = group_entries.first().group_id
+        self.assertTrue(
+            GroupIndividual.objects.filter(group_id=group_id, individual_id=individual1.id)
+        )
+        group = Group.objects.get(id=group_id)
+        self.assertEqual(group.location.name, json_ext1['location_name'])
+
 
     @patch('individual.apps.IndividualConfig.enable_maker_checker_for_individual_upload', True)
     def test_process_import_individuals_workflow_with_all_valid_entries_with_maker_checker(self):

--- a/individual/tests/test_workflows_utils.py
+++ b/individual/tests/test_workflows_utils.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+from unittest.mock import patch, MagicMock
+from core.test_helpers import create_test_interactive_user
+from individual.workflows.utils import SqlProcedurePythonWorkflow, PythonWorkflowHandlerException
+import pandas as pd
+import json
+import uuid
+
+class TestBasePythonWorkflowExecutor(TestCase):
+
+    def setUp(self):
+        self.user = create_test_interactive_user(username="admin")
+        self.upload_id = uuid.uuid4()
+
+        # Patch IndividualConfig schema and load_dataframe function
+        self.individual_schema = {
+            "properties": {
+                "email": {"type": "string", "uniqueness": True},
+                "able_bodied": {"type": "boolean"},
+            }
+        }
+        self.mock_load_dataframe = patch('individual.workflows.utils.load_dataframe').start()
+        self.mock_load_dataframe.return_value = pd.DataFrame()
+        patch(
+            'individual.workflows.utils.IndividualConfig.individual_schema',
+            json.dumps(self.individual_schema)
+        ).start()
+
+        self.executor = SqlProcedurePythonWorkflow(self.upload_id, self.user.id)
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_validate_dataframe_headers_valid(self):
+        self.executor.df = pd.DataFrame(columns=['first_name', 'last_name', 'dob', 'id', 'location_name'])
+        try:
+            self.executor.validate_dataframe_headers()
+        except PythonWorkflowHandlerException:
+            self.fail("validate_dataframe_headers() raised PythonWorkflowHandlerException unexpectedly!")
+
+    def test_validate_dataframe_headers_missing_required_fields(self):
+        # DataFrame missing required 'first_name' column
+        self.executor.df = pd.DataFrame(columns=['last_name', 'dob', 'id', 'location_name'])
+
+        with self.assertRaises(PythonWorkflowHandlerException) as cm:
+            self.executor.validate_dataframe_headers()
+
+        self.assertIn("Uploaded individuals missing essential header: first_name", str(cm.exception))
+
+    def test_validate_dataframe_headers_invalid_headers(self):
+        # DataFrame with an invalid column
+        self.executor.df = pd.DataFrame(columns=['first_name', 'last_name', 'dob', 'id', 'location_name', 'unexpected_column'])
+
+        with self.assertRaises(PythonWorkflowHandlerException) as cm:
+            self.executor.validate_dataframe_headers()
+
+        self.assertIn("Uploaded individuals contains invalid columns: {'unexpected_column'}", str(cm.exception))
+
+    def test_validate_dataframe_headers_update_missing_id(self):
+        # DataFrame missing 'ID' when is_update=True
+        columns = ['first_name', 'last_name', 'dob', 'id', 'location_name']
+        self.executor.df = pd.DataFrame(columns=columns)
+
+        with self.assertRaises(PythonWorkflowHandlerException) as cm:
+            self.executor.validate_dataframe_headers(is_update=True)
+
+        self.assertIn("Uploaded individuals missing essential header: ID", str(cm.exception))
+
+        # adding ID should pass the validation
+        columns.append('ID')
+        self.executor.df = pd.DataFrame(columns=columns)
+        try:
+            self.executor.validate_dataframe_headers(is_update=True)
+        except PythonWorkflowHandlerException:
+            self.fail("validate_dataframe_headers() raised PythonWorkflowHandlerException unexpectedly!")
+

--- a/individual/tests/test_workflows_utils.py
+++ b/individual/tests/test_workflows_utils.py
@@ -32,7 +32,7 @@ class TestBasePythonWorkflowExecutor(TestCase):
         patch.stopall()
 
     def test_validate_dataframe_headers_valid(self):
-        self.executor.df = pd.DataFrame(columns=['first_name', 'last_name', 'dob', 'id', 'location_name'])
+        self.executor.df = pd.DataFrame(columns=['first_name', 'last_name', 'dob', 'id', 'location_name', 'location_code'])
         try:
             self.executor.validate_dataframe_headers()
         except PythonWorkflowHandlerException:
@@ -40,7 +40,7 @@ class TestBasePythonWorkflowExecutor(TestCase):
 
     def test_validate_dataframe_headers_missing_required_fields(self):
         # DataFrame missing required 'first_name' column
-        self.executor.df = pd.DataFrame(columns=['last_name', 'dob', 'id', 'location_name'])
+        self.executor.df = pd.DataFrame(columns=['last_name', 'dob', 'id', 'location_name', 'location_code'])
 
         with self.assertRaises(PythonWorkflowHandlerException) as cm:
             self.executor.validate_dataframe_headers()
@@ -49,7 +49,7 @@ class TestBasePythonWorkflowExecutor(TestCase):
 
     def test_validate_dataframe_headers_invalid_headers(self):
         # DataFrame with an invalid column
-        self.executor.df = pd.DataFrame(columns=['first_name', 'last_name', 'dob', 'id', 'location_name', 'unexpected_column'])
+        self.executor.df = pd.DataFrame(columns=['first_name', 'last_name', 'dob', 'id', 'location_name', 'location_code', 'unexpected_column'])
 
         with self.assertRaises(PythonWorkflowHandlerException) as cm:
             self.executor.validate_dataframe_headers()
@@ -58,7 +58,7 @@ class TestBasePythonWorkflowExecutor(TestCase):
 
     def test_validate_dataframe_headers_update_missing_id(self):
         # DataFrame missing 'ID' when is_update=True
-        columns = ['first_name', 'last_name', 'dob', 'id', 'location_name']
+        columns = ['first_name', 'last_name', 'dob', 'id', 'location_name', 'location_code']
         self.executor.df = pd.DataFrame(columns=columns)
 
         with self.assertRaises(PythonWorkflowHandlerException) as cm:

--- a/individual/tests/view_test.py
+++ b/individual/tests/view_test.py
@@ -1,14 +1,20 @@
-from unittest.mock import patch
-from django.test import TestCase
-from rest_framework.test import APIClient
+import os
+from unittest.mock import patch, MagicMock
+from rest_framework.test import APITestCase
 from rest_framework import status
 from django.urls import reverse
 from core.test_helpers import create_test_interactive_user
 
 
-class ViewTest(TestCase):
+class ViewTest(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_file_path = os.path.join(
+            os.path.dirname(__file__), 'fixtures', 'individual_upload.csv'
+        )
+
     def setUp(self):
-        self.client = APIClient()
         self.admin_user = create_test_interactive_user()
 
     def test_download_template_file(self):
@@ -17,9 +23,11 @@ class ViewTest(TestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         self.assertEqual(response['Content-Type'], 'text/csv')
-        self.assertIn('attachment; filename="individual_upload_template.csv"', response['Content-Disposition'])
+        self.assertIn(
+            'attachment; filename="individual_upload_template.csv"',
+            response['Content-Disposition']
+        )
 
         expected_base_csv_header = f'first_name,last_name,dob,location_name,id'
         content = b"".join(response.streaming_content).decode('utf-8')
@@ -27,3 +35,122 @@ class ViewTest(TestCase):
             expected_base_csv_header in content,
             f'Expect csv template header to contain {expected_base_csv_header}, but got {content}'
         )
+
+    @patch('individual.views.WorkflowService')
+    @patch('individual.views.IndividualImportService')
+    @patch('individual.views.DefaultStorageFileHandler')
+    def test_import_individuals_success(
+            self, mock_file_handler, mock_individual_import_service, mock_workflow_service):
+
+        self.client.force_authenticate(user=self.admin_user)
+
+        mock_workflow_service.get_workflows.return_value = {
+            'success': True,
+            'data': {
+                'workflows': [{'id': 1, 'name': 'Test Workflow'}]
+            }
+        }
+
+        mock_individual_import_service.return_value.import_individuals.return_value = {
+            'success': True,
+            'message': 'Import successful',
+            'details': None
+        }
+
+        mock_handler_instance = MagicMock()
+        mock_file_handler.return_value = mock_handler_instance
+
+        with open(self.test_file_path, 'rb') as test_file:
+            response = self.client.post(
+                reverse('import_individuals'),
+                data={
+                    'file': test_file,
+                    'workflow_name': 'Test Workflow',
+                    'workflow_group': 'Test Group',
+                    'group_aggregation_column': 'group_code'
+                },
+                format='multipart'
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['success'], True)
+        self.assertIn('message', response.data)
+
+        mock_handler_instance.save_file.assert_called_once()
+
+    @patch('individual.views.WorkflowService')
+    @patch('individual.views.IndividualImportService')
+    @patch('individual.views.DefaultStorageFileHandler')
+    def test_import_individuals_import_service_failure(
+            self, mock_file_handler, mock_individual_import_service, mock_workflow_service):
+
+        self.client.force_authenticate(user=self.admin_user)
+
+        mock_handler_instance = MagicMock()
+        mock_file_handler.return_value = mock_handler_instance
+
+        mock_individual_import_service.return_value.import_individuals.return_value = {
+            'success': False,
+            'message': 'Import service not available',
+            'details': 'Dummy import service issue'
+        }
+
+        mock_workflow_service.get_workflows.return_value = {
+            'success': True,
+            'data': {
+                'workflows': [{'id': 1, 'name': 'Test Workflow'}]
+            }
+        }
+
+        with open(self.test_file_path, 'rb') as test_file:
+            response = self.client.post(
+                reverse('import_individuals'),
+                data={
+                    'file': test_file,
+                    'workflow_name': 'Test Workflow',
+                    'workflow_group': 'Test Group',
+                    'group_aggregation_column': 'group_code'
+                },
+                format='multipart'
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.data)
+
+        mock_handler_instance.save_file.assert_called_once()
+        mock_handler_instance.remove_file.assert_called_once()
+
+
+    @patch('individual.views.WorkflowService')
+    @patch('individual.views.DefaultStorageFileHandler')
+    def test_import_individuals_workflow_service_failure(
+            self, mock_file_handler, mock_workflow_service):
+
+        self.client.force_authenticate(user=self.admin_user)
+
+        mock_handler_instance = MagicMock()
+        mock_file_handler.return_value = mock_handler_instance
+
+        mock_workflow_service.get_workflows.return_value = {
+            'success': False,
+            'message': 'Workflow service not available',
+            'details': 'Dummy workflow service issue'
+        }
+
+        with open(self.test_file_path, 'rb') as test_file:
+            response = self.client.post(
+                reverse('import_individuals'),
+                data={
+                    'file': test_file,
+                    'workflow_name': 'Test Workflow',
+                    'workflow_group': 'Test Group',
+                    'group_aggregation_column': 'group_code'
+                },
+                format='multipart'
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.data)
+
+        mock_handler_instance.save_file.assert_not_called()
+        mock_handler_instance.remove_file.assert_not_called()

--- a/individual/tests/view_test.py
+++ b/individual/tests/view_test.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.urls import reverse
+from core.test_helpers import create_test_interactive_user
+
+
+class ViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin_user = create_test_interactive_user()
+
+    def test_download_template_file(self):
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('download_template_file')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertIn('attachment; filename="individual_upload_template.csv"', response['Content-Disposition'])
+
+        expected_base_csv_header = f'first_name,last_name,dob,location_name,id'
+        content = b"".join(response.streaming_content).decode('utf-8')
+        self.assertTrue(
+            expected_base_csv_header in content,
+            f'Expect csv template header to contain {expected_base_csv_header}, but got {content}'
+        )

--- a/individual/urls.py
+++ b/individual/urls.py
@@ -11,5 +11,5 @@ urlpatterns = [
     path('import_individuals/', import_individuals),
     path('download_invalid_items/', download_invalid_items),
     path('download_individual_upload_file/', download_individual_upload),
-    path('download_template_file/', download_template_file),
+    path('download_template_file/', download_template_file, name='download_template_file'),
 ]

--- a/individual/urls.py
+++ b/individual/urls.py
@@ -8,7 +8,7 @@ from .views import (
 )
 
 urlpatterns = [
-    path('import_individuals/', import_individuals),
+    path('import_individuals/', import_individuals, name='import_individuals'),
     path('download_invalid_items/', download_invalid_items),
     path('download_individual_upload_file/', download_individual_upload),
     path('download_template_file/', download_template_file, name='download_template_file'),

--- a/individual/views.py
+++ b/individual/views.py
@@ -4,7 +4,7 @@ import json
 import numpy as np
 import pandas as pd
 from django.db.models import Q
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import StreamingHttpResponse
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
@@ -20,25 +20,6 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from workflow.services import WorkflowService
 
 logger = logging.getLogger(__name__)
-
-_import_loaders = {
-    # .csv
-    'text/csv': lambda f, **kwargs: pd.read_csv(f, **kwargs),
-    # .xlsx
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': lambda f, **kwargs: pd.read_excel(f, **kwargs),
-    # .xls
-    'application/vnd.ms-excel': lambda f, **kwargs: pd.read_excel(f, **kwargs),
-    # .ods
-    'application/vnd.oasis.opendocument.spreadsheet': lambda f, **kwargs: pd.read_excel(f, **kwargs),
-}
-
-
-def load_spreadsheet(file: InMemoryUploadedFile, **kwargs) -> pd.DataFrame:
-    content_type = file.content_type
-    if content_type not in _import_loaders:
-        raise ValueError("Unsupported content type: {}".format(content_type))
-
-    return _import_loaders[content_type](file, **kwargs)
 
 
 def get_global_schema_fields():

--- a/individual/views.py
+++ b/individual/views.py
@@ -52,7 +52,7 @@ def get_global_schema_fields():
 @permission_classes([check_user_rights(IndividualConfig.gql_individual_create_perms, )])
 def download_template_file(request):
     try:
-        base_fields = ['first_name', 'last_name', 'dob', 'id']
+        base_fields = ['first_name', 'last_name', 'dob', 'location_name', 'id']
         extra_fields = get_global_schema_fields()
         all_fields = base_fields + extra_fields
         template_df = pd.DataFrame(columns=all_fields)

--- a/individual/views.py
+++ b/individual/views.py
@@ -33,7 +33,7 @@ def get_global_schema_fields():
 @permission_classes([check_user_rights(IndividualConfig.gql_individual_create_perms, )])
 def download_template_file(request):
     try:
-        base_fields = ['first_name', 'last_name', 'dob', 'location_name', 'id']
+        base_fields = IndividualConfig.individual_base_fields
         extra_fields = get_global_schema_fields()
         all_fields = base_fields + extra_fields
         template_df = pd.DataFrame(columns=all_fields)

--- a/individual/workflows/base_individual_update.py
+++ b/individual/workflows/base_individual_update.py
@@ -80,9 +80,13 @@ BEGIN
             SET first_name = COALESCE(f."Json_ext"->>'first_name', first_name),
             last_name = COALESCE(f."Json_ext"->>'last_name', last_name),
             dob = COALESCE(to_date(f."Json_ext"->>'dob', 'YYYY-MM-DD'), dob),
+            location_id = loc."LocationId",
             "DateUpdated" = NOW(),
             "Json_ext" = f."Json_ext"
             FROM individual_individualdatasource f
+            LEFT JOIN "tblLocations" AS loc
+                    ON loc."LocationName" = f."Json_ext"->>'location_name'
+                    AND loc."LocationType"='V'
             WHERE individual_individual."UUID" = (f."Json_ext" ->> 'ID')::UUID
             returning individual_individual."UUID", f."UUID" as "individualdatasource_id")
 

--- a/individual/workflows/base_individual_update.py
+++ b/individual/workflows/base_individual_update.py
@@ -88,6 +88,7 @@ BEGIN
                     ON loc."LocationName" = f."Json_ext"->>'location_name'
                     AND loc."LocationCode" = f."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
+                    AND loc."ValidityTo" IS NULL
             WHERE individual_individual."UUID" = (f."Json_ext" ->> 'ID')::UUID
             returning individual_individual."UUID", f."UUID" as "individualdatasource_id")
 

--- a/individual/workflows/base_individual_update.py
+++ b/individual/workflows/base_individual_update.py
@@ -86,6 +86,7 @@ BEGIN
             FROM individual_individualdatasource f
             LEFT JOIN "tblLocations" AS loc
                     ON loc."LocationName" = f."Json_ext"->>'location_name'
+                    AND loc."LocationCode" = f."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
             WHERE individual_individual."UUID" = (f."Json_ext" ->> 'ID')::UUID
             returning individual_individual."UUID", f."UUID" as "individualdatasource_id")

--- a/individual/workflows/base_individual_upload.py
+++ b/individual/workflows/base_individual_upload.py
@@ -71,6 +71,7 @@ DO $$
                     ON loc."LocationName" = ds."Json_ext"->>'location_name'
                     AND loc."LocationCode" = ds."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
+                    AND loc."ValidityTo" IS NULL
             WHERE ds.upload_id=current_upload_id 
                 AND ds.individual_id is null
                 AND ds."isDeleted"=False

--- a/individual/workflows/base_individual_upload.py
+++ b/individual/workflows/base_individual_upload.py
@@ -69,6 +69,7 @@ DO $$
             FROM individual_individualdatasource AS ds
             LEFT JOIN "tblLocations" AS loc
                     ON loc."LocationName" = ds."Json_ext"->>'location_name'
+                    AND loc."LocationCode" = ds."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
             WHERE ds.upload_id=current_upload_id 
                 AND ds.individual_id is null

--- a/individual/workflows/base_individual_upload.py
+++ b/individual/workflows/base_individual_upload.py
@@ -58,12 +58,21 @@ DO $$
           WITH new_entry AS (
             INSERT INTO individual_individual(
             "UUID", "isDeleted", version, "UserCreatedUUID", "UserUpdatedUUID",
-            "Json_ext", first_name, last_name, dob
+            "Json_ext", first_name, last_name, dob, location_id
             )
             SELECT gen_random_uuid(), false, 1, userUUID, userUUID,
-            "Json_ext", "Json_ext"->>'first_name', "Json_ext" ->> 'last_name', to_date("Json_ext" ->> 'dob', 'YYYY-MM-DD')
-            FROM individual_individualdatasource
-            WHERE upload_id=current_upload_id and individual_id is null and "isDeleted"=False
+                "Json_ext",
+                "Json_ext"->>'first_name',
+                "Json_ext" ->> 'last_name',
+                to_date("Json_ext" ->> 'dob', 'YYYY-MM-DD'),
+                loc."LocationId"
+            FROM individual_individualdatasource AS ds
+            LEFT JOIN "tblLocations" AS loc
+                    ON loc."LocationName" = ds."Json_ext"->>'location_name'
+                    AND loc."LocationType"='V'
+            WHERE ds.upload_id=current_upload_id 
+                AND ds.individual_id is null
+                AND ds."isDeleted"=False
             RETURNING "UUID", "Json_ext"  -- also return the Json_ext
           )
           UPDATE individual_individualdatasource

--- a/individual/workflows/individual_update_valid.py
+++ b/individual/workflows/individual_update_valid.py
@@ -91,6 +91,7 @@ BEGIN
             FROM individual_individualdatasource ids 
             LEFT JOIN "tblLocations" AS loc
                     ON loc."LocationName" = ids."Json_ext"->>'location_name'
+                    AND loc."LocationCode" = ids."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
             WHERE individual_individual."UUID" = (ids."Json_ext" ->> 'ID')::UUID
             AND ids.upload_id = current_upload_id
@@ -212,6 +213,7 @@ BEGIN
             FROM individual_individualdatasource ids
             LEFT JOIN "tblLocations" AS loc
                     ON loc."LocationName" = ids."Json_ext"->>'location_name'
+                    AND loc."LocationCode" = ids."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
             WHERE individual_individual."UUID" = (ids."Json_ext" ->> 'ID')::UUID 
             AND ids.upload_id = current_upload_id

--- a/individual/workflows/individual_update_valid.py
+++ b/individual/workflows/individual_update_valid.py
@@ -93,6 +93,7 @@ BEGIN
                     ON loc."LocationName" = ids."Json_ext"->>'location_name'
                     AND loc."LocationCode" = ids."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
+                    AND loc."ValidityTo" IS NULL
             WHERE individual_individual."UUID" = (ids."Json_ext" ->> 'ID')::UUID
             AND ids.upload_id = current_upload_id
             AND validations ->> 'validation_errors' = '[]'
@@ -215,6 +216,7 @@ BEGIN
                     ON loc."LocationName" = ids."Json_ext"->>'location_name'
                     AND loc."LocationCode" = ids."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
+                    AND loc."ValidityTo" IS NULL
             WHERE individual_individual."UUID" = (ids."Json_ext" ->> 'ID')::UUID 
             AND ids.upload_id = current_upload_id
             AND (ids."UUID" = ANY(accepted))

--- a/individual/workflows/individual_update_valid.py
+++ b/individual/workflows/individual_update_valid.py
@@ -83,11 +83,15 @@ BEGIN
             -- Update individual_individual
           with updated_individuals as ( UPDATE individual_individual
             SET first_name = COALESCE(ids."Json_ext"->>'first_name', first_name),
-            last_name = COALESCE(ids."Json_ext"->>'last_name', last_name),
-            dob = COALESCE(to_date(ids."Json_ext"->>'dob', 'YYYY-MM-DD'), dob),
-            "DateUpdated" = NOW(),
-            "Json_ext" = ids."Json_ext"
+                last_name = COALESCE(ids."Json_ext"->>'last_name', last_name),
+                dob = COALESCE(to_date(ids."Json_ext"->>'dob', 'YYYY-MM-DD'), dob),
+                location_id = loc."LocationId",
+                "DateUpdated" = NOW(),
+                "Json_ext" = ids."Json_ext"
             FROM individual_individualdatasource ids 
+            LEFT JOIN "tblLocations" AS loc
+                    ON loc."LocationName" = ids."Json_ext"->>'location_name'
+                    AND loc."LocationType"='V'
             WHERE individual_individual."UUID" = (ids."Json_ext" ->> 'ID')::UUID
             AND ids.upload_id = current_upload_id
             AND validations ->> 'validation_errors' = '[]'
@@ -202,9 +206,13 @@ BEGIN
             SET first_name = COALESCE(ids."Json_ext"->>'first_name', first_name),
                 last_name = COALESCE(ids."Json_ext"->>'last_name', last_name),
                 dob = COALESCE(to_date(ids."Json_ext"->>'dob', 'YYYY-MM-DD'), dob),
+                location_id = loc."LocationId",
                 "DateUpdated" = NOW(),
                 "Json_ext" = ids."Json_ext"
             FROM individual_individualdatasource ids
+            LEFT JOIN "tblLocations" AS loc
+                    ON loc."LocationName" = ids."Json_ext"->>'location_name'
+                    AND loc."LocationType"='V'
             WHERE individual_individual."UUID" = (ids."Json_ext" ->> 'ID')::UUID 
             AND ids.upload_id = current_upload_id
             AND (ids."UUID" = ANY(accepted))

--- a/individual/workflows/individual_upload_valid.py
+++ b/individual/workflows/individual_upload_valid.py
@@ -78,6 +78,7 @@ BEGIN
                     ON loc."LocationName" = ds."Json_ext"->>'location_name'
                     AND loc."LocationCode" = ds."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
+                    AND loc."ValidityTo" IS NULL
             WHERE ds.upload_id = current_upload_id
                 AND ds.individual_id IS NULL 
                 AND ds."isDeleted" = False 
@@ -195,6 +196,7 @@ BEGIN
                     ON loc."LocationName" = ds."Json_ext"->>'location_name'
                     AND loc."LocationCode" = ds."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
+                    AND loc."ValidityTo" IS NULL
             WHERE ds.upload_id = current_upload_id 
                 AND ds.individual_id IS NULL
                 AND ds."isDeleted" = False

--- a/individual/workflows/individual_upload_valid.py
+++ b/individual/workflows/individual_upload_valid.py
@@ -76,6 +76,7 @@ BEGIN
             FROM individual_individualdatasource AS ds
             LEFT JOIN "tblLocations" AS loc
                     ON loc."LocationName" = ds."Json_ext"->>'location_name'
+                    AND loc."LocationCode" = ds."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
             WHERE ds.upload_id = current_upload_id
                 AND ds.individual_id IS NULL 
@@ -109,7 +110,7 @@ BEGIN
             SET 
                 status = CASE
                     WHEN total_valid_entries = total_entries THEN 'SUCCESS'
-                    ELSE 'PARTIAL_SUCCESSsss'
+                    ELSE 'PARTIAL_SUCCESS'
                 END,
                 error = CASE
                     WHEN total_valid_entries < total_entries THEN jsonb_build_object(
@@ -192,6 +193,7 @@ BEGIN
             FROM individual_individualdatasource AS ds
             LEFT JOIN "tblLocations" AS loc
                     ON loc."LocationName" = ds."Json_ext"->>'location_name'
+                    AND loc."LocationCode" = ds."Json_ext"->>'location_code'
                     AND loc."LocationType"='V'
             WHERE ds.upload_id = current_upload_id 
                 AND ds.individual_id IS NULL

--- a/individual/workflows/individual_upload_valid.py
+++ b/individual/workflows/individual_upload_valid.py
@@ -29,6 +29,8 @@ DECLARE
     failing_entries_first_name UUID[];
     failing_entries_last_name UUID[];
     failing_entries_dob UUID[];
+    total_entries INT;
+    total_valid_entries INT;
 BEGIN
     -- Check if all required fields are present in the entries
     SELECT ARRAY_AGG("UUID") INTO failing_entries_first_name
@@ -63,12 +65,22 @@ BEGIN
         WITH new_entry AS (
             INSERT INTO individual_individual(
                 "UUID", "isDeleted", version, "UserCreatedUUID", "UserUpdatedUUID",
-                "Json_ext", first_name, last_name, dob
+                "Json_ext", first_name, last_name, dob, location_id
             )
             SELECT gen_random_uuid(), false, 1, userUUID, userUUID,
-                   "Json_ext", "Json_ext"->>'first_name', "Json_ext" ->> 'last_name', to_date("Json_ext" ->> 'dob', 'YYYY-MM-DD')
-            FROM individual_individualdatasource
-            WHERE upload_id = current_upload_id AND individual_id IS NULL AND "isDeleted" = False AND validations ->> 'validation_errors' = '[]'
+                   "Json_ext",
+                   "Json_ext"->>'first_name',
+                   "Json_ext" ->> 'last_name',
+                   to_date("Json_ext" ->> 'dob', 'YYYY-MM-DD'),
+                   loc."LocationId"
+            FROM individual_individualdatasource AS ds
+            LEFT JOIN "tblLocations" AS loc
+                    ON loc."LocationName" = ds."Json_ext"->>'location_name'
+                    AND loc."LocationType"='V'
+            WHERE ds.upload_id = current_upload_id
+                AND ds.individual_id IS NULL 
+                AND ds."isDeleted" = False 
+                AND ds.validations ->> 'validation_errors' = '[]'
             RETURNING "UUID", "Json_ext"
         )
         UPDATE individual_individualdatasource
@@ -80,25 +92,35 @@ BEGIN
           AND individual_individualdatasource."Json_ext" = ne."Json_ext"
           AND validations ->> 'validation_errors' = '[]';
 
+        -- Calculate counts of valid and total entries
+        SELECT count(*) INTO total_valid_entries
+        FROM individual_individualdatasource
+        WHERE upload_id = current_upload_id
+          AND "isDeleted" = FALSE
+          AND COALESCE(validations ->> 'validation_errors', '[]') = '[]';
+
+        SELECT count(*) INTO total_entries
+        FROM individual_individualdatasource
+        WHERE upload_id = current_upload_id
+          AND "isDeleted" = FALSE;
+
         -- Change status to SUCCESS if no invalid items, change to PARTIAL_SUCCESS otherwise 
             UPDATE individual_individualdatasourceupload
             SET 
                 status = CASE
-                    WHEN (
-                        SELECT count(*) 
-                        FROM individual_individualdatasource
-                        WHERE upload_id=current_upload_id
-                            AND "isDeleted"=FALSE
-                            AND validations ->> 'validation_errors' = '[]'
-                    ) = (
-                        SELECT count(*) 
-                        FROM individual_individualdatasource
-                        WHERE upload_id=current_upload_id
-                            AND "isDeleted"=FALSE
-                    ) THEN 'SUCCESS'
-                    ELSE 'PARTIAL_SUCCESS'
+                    WHEN total_valid_entries = total_entries THEN 'SUCCESS'
+                    ELSE 'PARTIAL_SUCCESSsss'
                 END,
-                error = '{}'
+                error = CASE
+                    WHEN total_valid_entries < total_entries THEN jsonb_build_object(
+                        'error', 'Partial success due to some invalid entries',
+                        'timestamp', NOW()::text,
+                        'upload_id', current_upload_id::text,
+                        'total_valid_entries', total_valid_entries,
+                        'total_entries', total_entries
+                    )
+                    ELSE '{}'
+                END
             WHERE "UUID" = current_upload_id;
     END IF;
 EXCEPTION WHEN OTHERS THEN
@@ -159,12 +181,22 @@ BEGIN
         WITH new_entry AS (
             INSERT INTO individual_individual(
                 "UUID", "isDeleted", version, "UserCreatedUUID", "UserUpdatedUUID",
-                "Json_ext", first_name, last_name, dob
+                "Json_ext", first_name, last_name, dob, location_id
             )
             SELECT gen_random_uuid(), false, 1, userUUID, userUUID,
-                   "Json_ext", "Json_ext"->>'first_name', "Json_ext" ->> 'last_name', to_date("Json_ext" ->> 'dob', 'YYYY-MM-DD')
-            FROM individual_individualdatasource
-            WHERE upload_id = current_upload_id AND individual_id IS NULL AND "isDeleted" = False AND validations ->> 'validation_errors' = '[]'
+                   "Json_ext",
+                   "Json_ext"->>'first_name',
+                   "Json_ext" ->> 'last_name',
+                   to_date("Json_ext" ->> 'dob', 'YYYY-MM-DD'),
+                   loc."LocationId"
+            FROM individual_individualdatasource AS ds
+            LEFT JOIN "tblLocations" AS loc
+                    ON loc."LocationName" = ds."Json_ext"->>'location_name'
+                    AND loc."LocationType"='V'
+            WHERE ds.upload_id = current_upload_id 
+                AND ds.individual_id IS NULL
+                AND ds."isDeleted" = False
+                AND ds.validations ->> 'validation_errors' = '[]'
             AND (accepted IS NULL OR "UUID" = ANY(accepted))
             RETURNING "UUID", "Json_ext"
         )

--- a/individual/workflows/utils.py
+++ b/individual/workflows/utils.py
@@ -52,7 +52,7 @@ class BasePythonWorkflowExecutor(metaclass=ABCMeta):
         df_headers = set(self.df.columns)
         schema_properties = set(self.schema.get('properties', {}).keys())
         schema_properties.update(['recipient_info', 'group_code', 'individual_role'])
-        required_headers = {'first_name', 'last_name', 'dob', 'id'}
+        required_headers = set(IndividualConfig.individual_base_fields)
         if is_update:
             required_headers.add('ID')
 


### PR DESCRIPTION
- [x] validate_import_individuals (used by DataUploadWorkflow and DataUpdateWorkflow) --- services.py
- [x] import_individuals ---- views.py
- [x] download_template_file
- [x] download_invalid_items
- [x] download_individual_upload
- [x] base_individual_upload --- workflows
- [x] individual_upload_valid 
- [x] base_individual_update
- [x] individual_update_valid 

In the process of working on this feature I added tests to cover the existing functionalities of the template download, import, and import validation. I also came across some previous refactoring – I believe to address the performance issue of individual uniqueness validation – that is incomplete, as evidenced by the leftover unused code. There was also a bug uncovered by the added tests, so I'm putting up this draft PR for quick review by @sniedzielski first of the refactored change and bug fix.

Also, @sniedzielski, not sure if you are aware, the with code before this PR the uniqueness check doesn't use the code in calcrule_validations/strategies/deduplication_individual_validation_strategy.py anymore, to which you are the original author and instead the uniqueness validation result is simply `national_id_uniqueness: false`. This PR puts back the dictionary structure but doesn't put back the attribute `duplications` as it would involve lots of database calls (which I believe was where the performance optimization your teammate did), so now with the PR, the validation result becomes 
```
"national_id_uniqueness":{
               "success": false,
               "field_name": "national_id",
               "note": "'national_id' Field value '1345320000AN' is duplicated",
}
```
Can you have a look at the relevant changes in this PR and let me know if it's ok? If so, I'll also go ahead and update the social_protection module's README to remove the duplications sample output to keep things consistent: https://github.com/openimis/openimis-be-social_protection_py/blob/b7c5359cf78898c061c7482bddff3c273adbf96f/README.md?plain=1#L202-L274

Should deduplication_individual_validation_strategy.py be removed from calcrule_validations if it's not used anymore?