### PR TITLE
OP-2163: added possibility to configure check for delete operation

### DIFF
--- a/individual/apps.py
+++ b/individual/apps.py
@@ -21,6 +21,7 @@ DEFAULT_CONFIG = {
     "check_individual_delete": True,
     "check_group_individual_update": True,
     "check_group_create": True,
+    "check_group_delete": True,
     "individual_schema": "{}",
     "individual_accept_enrolment": "individual_service.create_accept_enrolment_task",
     "validation_import_valid_items_workflow": "individual-import-valid-items",
@@ -61,6 +62,7 @@ class IndividualConfig(AppConfig):
     check_individual_delete = None
     check_group_individual_update = None
     check_group_create = None
+    check_group_delete = None
     python_individual_import_workflow_group = None
     python_individual_import_workflow_name = None
     individual_schema = None

--- a/individual/gql_mutations.py
+++ b/individual/gql_mutations.py
@@ -337,7 +337,11 @@ class DeleteGroupMutation(BaseHistoryModelDeleteMutationMixin, BaseMutation):
         if ids:
             with transaction.atomic():
                 for identifier in ids:
-                    service.delete({'id': identifier})
+                    obj_data = {'id': identifier}
+                    if IndividualConfig.check_group_delete:
+                        service.create_delete_task(obj_data)
+                    else:
+                        service.delete(obj_data)
 
     class Input(OpenIMISMutation.Input):
         ids = graphene.List(graphene.UUID)

--- a/individual/services.py
+++ b/individual/services.py
@@ -149,7 +149,12 @@ class IndividualDataSourceService(BaseService):
         super().__init__(user, validation_class)
 
 
-class GroupService(BaseService, CreateCheckerLogicServiceMixin, UpdateCheckerLogicServiceMixin):
+class GroupService(
+    BaseService,
+    CreateCheckerLogicServiceMixin,
+    UpdateCheckerLogicServiceMixin,
+    DeleteCheckerLogicServiceMixin
+):
     OBJECT_TYPE = Group
 
     def __init__(self, user, validation_class=GroupValidation):

--- a/individual/tests/graphql_mutation_group_test.py
+++ b/individual/tests/graphql_mutation_group_test.py
@@ -404,6 +404,129 @@ class GroupGQLMutationTest(IndividualGQLTestCase):
         )
         self.assertEqual(group_individual_query.count(), 0)
 
+    @patch.object(IndividualConfig, 'check_group_delete', new=False)
+    def test_delete_group_with_individual_row_security(self):
+        individual_a1, group_a1 = create_group_with_individual(
+            self.admin_user.username,
+            group_override={'location': self.village_a},
+            individual_override={'location': self.village_a},
+        )
+        individual_a2, group_a2 = create_group_with_individual(
+            self.admin_user.username,
+            group_override={'location': self.village_a},
+            individual_override={'location': self.village_a},
+        )
+        individual_b, group_b = create_group_with_individual(
+            self.admin_user.username,
+            group_override={'location': self.village_b},
+            individual_override={'location': self.village_b},
+        )
+        query_str = f'''
+            mutation {{
+              deleteGroup(
+                input: {{
+                  ids: ["{group_a1.id}"]
+                }}
+              ) {{
+                clientMutationId
+                internalId
+              }}
+            }}
+        '''
+
+        # SP officer B cannot delete group for district A
+        response = self.query(query_str)
+        content = json.loads(response.content)
+        internal_id = content['data']['deleteGroup']['internalId']
+        self.assert_mutation_error(internal_id, _('mutation.authentication_required'))
+        group_individual_query = GroupIndividual.objects.filter(
+            is_deleted=False,
+            group=group_a1
+        )
+        self.assertEqual(group_individual_query.count(), 1)
+
+        response = self.query(
+            query_str,
+            headers={"HTTP_AUTHORIZATION": f"Bearer {self.dist_b_user_token}"}
+        )
+        self.assertResponseNoErrors(response)
+
+        content = json.loads(response.content)
+        internal_id = content['data']['deleteGroup']['internalId']
+        self.assert_mutation_error(internal_id, _('unauthorized.location'))
+        group_individual_query = GroupIndividual.objects.filter(
+            is_deleted=False,
+            group=group_a1
+        )
+        self.assertEqual(group_individual_query.count(), 1)
+
+        # SP officer A can delete group for district A
+        response = self.query(
+            query_str,
+            headers={"HTTP_AUTHORIZATION": f"Bearer {self.dist_a_user_token}"}
+        )
+        content = json.loads(response.content)
+        internal_id = content['data']['deleteGroup']['internalId']
+        self.assert_mutation_success(internal_id)
+
+        # SP officer B can delete group without any district
+        individual_no_loc, group_no_loc = create_group_with_individual(self.admin_user.username)
+        group_individual_query = GroupIndividual.objects.filter(
+            is_deleted=False,
+            group=group_no_loc
+        )
+        self.assertEqual(group_individual_query.count(), 1)
+        response = self.query(
+            query_str.replace(
+                str(group_a1.id),
+                str(group_no_loc.id)
+            ), headers={"HTTP_AUTHORIZATION": f"Bearer {self.dist_b_user_token}"}
+        )
+        content = json.loads(response.content)
+        internal_id = content['data']['deleteGroup']['internalId']
+        self.assert_mutation_success(internal_id)
+        group_individual_query = GroupIndividual.objects.filter(
+            is_deleted=False,
+            group=group_no_loc
+        )
+        self.assertEqual(group_individual_query.count(), 0)
+
+        # SP officer B cannot delete a mix of groups from district A and district B
+        response = self.query(
+            query_str.replace(
+                f'["{group_a1.id}"]',
+                f'["{group_a1.id}", "{group_b.id}"]'
+            ), headers={"HTTP_AUTHORIZATION": f"Bearer {self.dist_b_user_token}"}
+        )
+        content = json.loads(response.content)
+        internal_id = content['data']['deleteGroup']['internalId']
+        self.assert_mutation_error(internal_id, _('unauthorized.location'))
+        group_individual_query = GroupIndividual.objects.filter(
+            is_deleted=False,
+            group=group_b
+        )
+        self.assertEqual(group_individual_query.count(), 1)
+        group_individual_query = GroupIndividual.objects.filter(
+            is_deleted=False,
+            group=group_a1
+        )
+        self.assertEqual(group_individual_query.count(), 0)
+
+        # SP officer B can delete group from district B
+        response = self.query(
+            query_str.replace(
+                str(group_a1.id),
+                str(group_b.id)
+            ), headers={"HTTP_AUTHORIZATION": f"Bearer {self.dist_b_user_token}"}
+        )
+        content = json.loads(response.content)
+        internal_id = content['data']['deleteGroup']['internalId']
+        self.assert_mutation_success(internal_id)
+        group_individual_query = GroupIndividual.objects.filter(
+            is_deleted=False,
+            group=group_b
+        )
+        self.assertEqual(group_individual_query.count(), 0)
 
     def test_add_individual_to_group_general_permission(self):
         group = create_group(self.admin_user.username)

--- a/individual/tests/graphql_mutation_group_test.py
+++ b/individual/tests/graphql_mutation_group_test.py
@@ -406,17 +406,17 @@ class GroupGQLMutationTest(IndividualGQLTestCase):
 
     @patch.object(IndividualConfig, 'check_group_delete', new=False)
     def test_delete_group_with_individual_row_security(self):
-        individual_a1, group_a1 = create_group_with_individual(
+        individual_a1, group_a1, group_individual_a1 = create_group_with_individual(
             self.admin_user.username,
             group_override={'location': self.village_a},
             individual_override={'location': self.village_a},
         )
-        individual_a2, group_a2 = create_group_with_individual(
+        individual_a2, group_a2, group_individual_a2 = create_group_with_individual(
             self.admin_user.username,
             group_override={'location': self.village_a},
             individual_override={'location': self.village_a},
         )
-        individual_b, group_b = create_group_with_individual(
+        individual_b, group_b, group_individual_b = create_group_with_individual(
             self.admin_user.username,
             group_override={'location': self.village_b},
             individual_override={'location': self.village_b},
@@ -470,7 +470,9 @@ class GroupGQLMutationTest(IndividualGQLTestCase):
         self.assert_mutation_success(internal_id)
 
         # SP officer B can delete group without any district
-        individual_no_loc, group_no_loc = create_group_with_individual(self.admin_user.username)
+        individual_no_loc, group_no_loc, group_individual_no_loc = create_group_with_individual(
+            self.admin_user.username
+        )
         group_individual_query = GroupIndividual.objects.filter(
             is_deleted=False,
             group=group_no_loc

--- a/individual/tests/group_service_test.py
+++ b/individual/tests/group_service_test.py
@@ -118,6 +118,34 @@ class GroupServiceTest(TestCase):
         # self.assertFalse(individual2.id in individual_ids)
         self.assertTrue(individual3.id in individual_ids)
 
+    def test_delete_group_with_individual(self):
+        individual1 = self.__create_individual()
+        individual2 = self.__create_individual()
+        individual3 = self.__create_individual()
+        payload_individuals = {
+            'code': str(datetime.now()),
+            'individuals_data': [
+                {'individual_id': str(individual1.id)},
+                {'individual_id': str(individual2.id)},
+            ]
+        }
+        result = self.service.create(payload_individuals)
+        self.assertTrue(result.get('success', False), result.get('detail', "No details provided"))
+        uuid = result.get('data', {}).get('uuid', None)
+        query = self.query_all.filter(uuid=uuid)
+        group = query.first()
+        self.assertEqual(query.count(), 1)
+        self.assertEqual(str(group.id), uuid)
+        group_individual_query = self.group_individual_query_all.filter(group=group)
+        self.assertEqual(group_individual_query.count(), 2)
+        delete_payload = {'id': uuid}
+        result = self.service.delete(delete_payload)
+        self.assertTrue(result.get('success', False), result.get('detail', "No details provided"))
+        query = self.query_all.filter(uuid=uuid)
+        self.assertEqual(query.count(), 0)
+        group_individual_query = self.group_individual_query_all.filter(group=group)
+        self.assertEqual(group_individual_query.count(), 0)
+
     @classmethod
     def __create_individual(cls):
         object_data = {

--- a/individual/tests/group_service_test.py
+++ b/individual/tests/group_service_test.py
@@ -121,7 +121,6 @@ class GroupServiceTest(TestCase):
     def test_delete_group_with_individual(self):
         individual1 = self.__create_individual()
         individual2 = self.__create_individual()
-        individual3 = self.__create_individual()
         payload_individuals = {
             'code': str(datetime.now()),
             'individuals_data': [


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-2163

- add missing maker-checker logic for deleting group
- make possibility to enable/disable by config - by default maker checker is enabled for Group Deletion