### PR TITLE
Make group code non-required for group update mutation

### DIFF
--- a/individual/gql_mutations.py
+++ b/individual/gql_mutations.py
@@ -63,8 +63,11 @@ class CreateGroupInputType(OpenIMISMutation.Input):
     location_id = graphene.Int(required=False)
 
 
-class UpdateGroupInputType(CreateGroupInputType):
+class UpdateGroupInputType(OpenIMISMutation.Input):
     id = graphene.UUID(required=True)
+    code = graphene.String(required=False)
+    individuals_data = graphene.List(CreateGroupIndividualInputTypeInputObjectType, required=False)
+    location_id = graphene.Int(required=False)
 
 
 class UpdateGroupIndividualInputType(CreateGroupIndividualInputType):

--- a/individual/tests/graphql_mutation_group_test.py
+++ b/individual/tests/graphql_mutation_group_test.py
@@ -128,7 +128,6 @@ class GroupGQLMutationTest(IndividualGQLTestCase):
               updateGroup(
                 input: {{
                   id: "{group.id}"
-                  code: "GFOO"
                   locationId: {self.village_a.id}
                 }}
               ) {{
@@ -138,21 +137,21 @@ class GroupGQLMutationTest(IndividualGQLTestCase):
             }}
         '''
 
-        # Anonymous User has no permission
-        response = self.query(query_str)
-
-        content = json.loads(response.content)
-        internal_id = content['data']['updateGroup']['internalId']
-        self.assert_mutation_error(internal_id, _('mutation.authentication_required'))
-
         # IMIS admin can do everything
         response = self.query(
             query_str,
             headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
         )
+        self.assertResponseNoErrors(response)
         content = json.loads(response.content)
         internal_id = content['data']['updateGroup']['internalId']
         self.assert_mutation_success(internal_id)
+
+        # Anonymous User has no permission
+        response = self.query(query_str)
+        content = json.loads(response.content)
+        internal_id = content['data']['updateGroup']['internalId']
+        self.assert_mutation_error(internal_id, _('mutation.authentication_required'))
 
         # Health Enrollment Officier (role=1) has no permission
         response = self.query(


### PR DESCRIPTION
The frontend [disabled the group code from being edited](https://github.com/openimis/openimis-fe-individual_js/blob/develop/src/components/GroupHeadPanel.js#L59) so the code should not be required in the update input payload.