### PR TITLE
Fix max active beneficiaries

### DIFF
--- a/individual/gql_mutations.py
+++ b/individual/gql_mutations.py
@@ -13,6 +13,7 @@ from individual.models import Individual, Group, GroupIndividual
 from individual.services import IndividualService, GroupService, GroupIndividualService, \
     CreateGroupAndMoveIndividualService
 from location.models import Location, LocationManager
+from social_protection.apps import SocialProtectionConfig
 
 
 class CreateIndividualInputType(OpenIMISMutation.Input):
@@ -30,6 +31,7 @@ class UpdateIndividualInputType(CreateIndividualInputType):
 RoleEnum = graphene.Enum.from_enum(GroupIndividual.Role)
 RecipientTypeEnum = graphene.Enum.from_enum(GroupIndividual.RecipientType)
 
+DEFAULT_BENEFICIARY_STATUS = SocialProtectionConfig.default_beneficiary_status
 
 class CreateGroupIndividualInputType(OpenIMISMutation.Input):
     group_id = graphene.UUID(required=False)
@@ -571,7 +573,8 @@ class ConfirmIndividualEnrollmentMutation(BaseHistoryModelCreateMutationMixin, B
             data.pop('client_mutation_label')
         custom_filters = data.pop('custom_filters', None)
         benefit_plan_id = data.pop('benefit_plan_id', None)
-        status = data.pop('status', "ACTIVE")
+        # TODO check consistency of default status
+        status = data.pop('status', DEFAULT_BENEFICIARY_STATUS)
         service = IndividualService(user)
         service.select_individuals_to_benefit_plan(
             custom_filters,
@@ -605,7 +608,7 @@ class ConfirmGroupEnrollmentMutation(BaseHistoryModelCreateMutationMixin, BaseMu
             data.pop('client_mutation_label')
         custom_filters = data.pop('custom_filters', None)
         benefit_plan_id = data.pop('benefit_plan_id', None)
-        status = data.pop('status', "ACTIVE")
+        status = data.pop('status', DEFAULT_BENEFICIARY_STATUS)
         service = GroupService(user)
         service.select_groups_to_benefit_plan(
             custom_filters,

--- a/individual/gql_queries.py
+++ b/individual/gql_queries.py
@@ -275,21 +275,25 @@ class GroupDataSourceGQLType(DjangoObjectType):
 
 
 class IndividualSummaryEnrollmentGQLType(graphene.ObjectType):
-    number_of_selected_individuals = graphene.String()
-    total_number_of_individuals = graphene.String()
-    number_of_individuals_not_assigned_to_programme = graphene.String()
-    number_of_individuals_assigned_to_programme = graphene.String()
-    number_of_individuals_assigned_to_selected_programme = graphene.String()
-    number_of_individuals_to_upload = graphene.String()
+    number_of_selected_individuals = graphene.Int()
+    total_number_of_individuals = graphene.Int()
+    number_of_individuals_not_assigned_to_programme = graphene.Int()
+    number_of_individuals_assigned_to_programme = graphene.Int()
+    number_of_individuals_assigned_to_selected_programme = graphene.Int()
+    number_of_individuals_assigned_to_selected_programme_and_status = graphene.Int()
+    number_of_individuals_to_upload = graphene.Int()
+    max_active_beneficiaries_exceeded = graphene.Boolean()
 
 
 class GroupSummaryEnrollmentGQLType(graphene.ObjectType):
-    number_of_selected_groups = graphene.String()
-    total_number_of_groups = graphene.String()
-    number_of_groups_not_assigned_to_programme = graphene.String()
-    number_of_groups_assigned_to_programme = graphene.String()
-    number_of_groups_assigned_to_selected_programme = graphene.String()
-    number_of_groups_to_upload = graphene.String()
+    number_of_selected_groups = graphene.Int()
+    total_number_of_groups = graphene.Int()
+    number_of_groups_not_assigned_to_programme = graphene.Int()
+    number_of_groups_assigned_to_programme = graphene.Int()
+    number_of_groups_assigned_to_selected_programme = graphene.Int()
+    number_of_groups_assigned_to_selected_programme_and_status = graphene.Int()
+    number_of_groups_to_upload = graphene.Int()
+    max_active_beneficiaries_exceeded = graphene.Boolean()
 
 
 class GlobalSchemaType(graphene.ObjectType):

--- a/individual/schema.py
+++ b/individual/schema.py
@@ -26,6 +26,7 @@ from individual.gql_queries import IndividualGQLType, IndividualHistoryGQLType, 
 from individual.models import Individual, IndividualDataSource, Group, \
     GroupIndividual, IndividualDataSourceUpload, IndividualDataUploadRecords, GroupDataSource
 from individual.services import IndividualService, GroupService
+from social_protection.apps import SocialProtectionConfig
 from location.apps import LocationConfig
 
 
@@ -39,6 +40,7 @@ def patch_details(data_df: pd.DataFrame):
         return df_final
     return data_df
 
+DEFAULT_BENEFICIARY_STATUS = SocialProtectionConfig.default_beneficiary_status
 
 class Query(ExportableQueryMixin, graphene.ObjectType):
     export_patches = {
@@ -224,7 +226,7 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
         service = IndividualService(user)
         custom_filters = kwargs.get("customFilters", None)
         benefit_plan_id = kwargs.get("benefitPlanId", None)
-        status = kwargs.get("status", "ACTIVE")
+        status = kwargs.get("status", DEFAULT_BENEFICIARY_STATUS)
 
         enrollment_checks = service.run_enrollment_checks(
             custom_filters,
@@ -420,7 +422,7 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
         service = GroupService(user)
         custom_filters = kwargs.get("customFilters", None)
         benefit_plan_id = kwargs.get("benefitPlanId", None)
-        status = kwargs.get("status", "ACTIVE")
+        status = kwargs.get("status", DEFAULT_BENEFICIARY_STATUS)
 
         enrollment_checks = service.run_enrollment_checks(
             custom_filters,

--- a/individual/schema.py
+++ b/individual/schema.py
@@ -25,6 +25,7 @@ from individual.gql_queries import IndividualGQLType, IndividualHistoryGQLType, 
     GroupSummaryEnrollmentGQLType, GroupDataSourceGQLType
 from individual.models import Individual, IndividualDataSource, Group, \
     GroupIndividual, IndividualDataSourceUpload, IndividualDataUploadRecords, GroupDataSource
+from individual.services import IndividualService, GroupService
 from location.apps import LocationConfig
 
 
@@ -141,7 +142,8 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
     individual_enrollment_summary = graphene.Field(
         IndividualSummaryEnrollmentGQLType,
         customFilters=graphene.List(of_type=graphene.String),
-        benefitPlanId=graphene.String()
+        benefitPlanId=graphene.String(),
+        status=graphene.String(),
     )
 
     individual_data_upload_history = OrderedDjangoFilterConnectionField(
@@ -156,7 +158,8 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
     group_enrollment_summary = graphene.Field(
         GroupSummaryEnrollmentGQLType,
         customFilters=graphene.List(of_type=graphene.String),
-        benefitPlanId=graphene.String()
+        benefitPlanId=graphene.String(),
+        status=graphene.String(),
     )
 
     global_schema = graphene.Field(GlobalSchemaType)
@@ -215,43 +218,44 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
         return gql_optimizer.query(query, info)
 
     def resolve_individual_enrollment_summary(self, info, **kwargs):
-        Query._check_permissions(info.context.user,
-                                 IndividualConfig.gql_individual_search_perms)
-        subquery = GroupIndividual.objects.filter(individual=OuterRef('pk')).values('individual')
-        query = Individual.objects.filter(is_deleted=False)
+        user = info.context.user
+        Query._check_permissions(user, IndividualConfig.gql_individual_search_perms)
+        
+        service = IndividualService(user)
         custom_filters = kwargs.get("customFilters", None)
         benefit_plan_id = kwargs.get("benefitPlanId", None)
-        if custom_filters:
-            query = CustomFilterWizardStorage.build_custom_filters_queryset(
-                Query.module_name,
-                Query.object_type,
-                custom_filters,
-                query,
-            )
-        query = query.filter(~Q(pk__in=Subquery(subquery))).distinct()
-        # Aggregation for selected individuals
-        number_of_selected_individuals = query.count()
+        status = kwargs.get("status", "ACTIVE")
 
-        # Aggregation for total number of individuals
-        total_number_of_individuals = Individual.objects.filter(is_deleted=False).count()
-        individuals_not_assigned_to_programme = query.\
+        enrollment_checks = service.run_enrollment_checks(
+            custom_filters,
+            benefit_plan_id,
+            status,
+            user
+        )
+
+        total_number_of_individuals = enrollment_checks["total_number_of_individuals"]
+        selected_individuals = enrollment_checks["individual_query_with_filters"]
+        num_assigned_to_selected_programme = enrollment_checks["individuals_assigned_to_selected_programme"].count()
+
+        number_of_individuals_assigned_to_selected_programme_and_status = enrollment_checks["num_individuals_assigned_to_selected_programme_and_status"]
+        number_of_individuals_to_upload = enrollment_checks["num_individuals_to_enroll"]
+        max_active_beneficiaries_exceeded = enrollment_checks["max_active_beneficiaries_exceeded"]
+
+        number_of_selected_individuals = selected_individuals.count()
+
+        num_individuals_not_assigned_to_programme = selected_individuals.\
             filter(is_deleted=False, beneficiary__benefit_plan_id__isnull=True).count()
-        individuals_assigned_to_programme = number_of_selected_individuals - individuals_not_assigned_to_programme
-
-        individuals_assigned_to_selected_programme = "0"
-        number_of_individuals_to_upload = number_of_selected_individuals
-        if benefit_plan_id:
-            individuals_assigned_to_selected_programme = query. \
-                filter(is_deleted=False, beneficiary__benefit_plan_id=benefit_plan_id).count()
-            number_of_individuals_to_upload = number_of_individuals_to_upload - individuals_assigned_to_selected_programme
+        num_individuals_assigned_to_programme = number_of_selected_individuals - num_individuals_not_assigned_to_programme
 
         return IndividualSummaryEnrollmentGQLType(
             number_of_selected_individuals=number_of_selected_individuals,
             total_number_of_individuals=total_number_of_individuals,
-            number_of_individuals_not_assigned_to_programme=individuals_not_assigned_to_programme,
-            number_of_individuals_assigned_to_programme=individuals_assigned_to_programme,
-            number_of_individuals_assigned_to_selected_programme=individuals_assigned_to_selected_programme,
-            number_of_individuals_to_upload=number_of_individuals_to_upload
+            number_of_individuals_not_assigned_to_programme=num_individuals_not_assigned_to_programme,
+            number_of_individuals_assigned_to_programme=num_individuals_assigned_to_programme,
+            number_of_individuals_assigned_to_selected_programme=num_assigned_to_selected_programme,
+            number_of_individuals_assigned_to_selected_programme_and_status=number_of_individuals_assigned_to_selected_programme_and_status,
+            number_of_individuals_to_upload=number_of_individuals_to_upload,
+            max_active_beneficiaries_exceeded=max_active_beneficiaries_exceeded
         )
 
     def resolve_individual_history(self, info, **kwargs):
@@ -410,41 +414,44 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
         return gql_optimizer.query(query, info)
 
     def resolve_group_enrollment_summary(self, info, **kwargs):
-        Query._check_permissions(info.context.user,
-                                 IndividualConfig.gql_group_search_perms)
-        query = Group.objects.filter(is_deleted=False)
+        user = info.context.user
+        Query._check_permissions(user, IndividualConfig.gql_group_search_perms)
+        
+        service = GroupService(user)
         custom_filters = kwargs.get("customFilters", None)
         benefit_plan_id = kwargs.get("benefitPlanId", None)
-        if custom_filters:
-            query = CustomFilterWizardStorage.build_custom_filters_queryset(
-                Query.module_name,
-                "Group",
-                custom_filters,
-                query,
-            )
-        # Aggregation for selected groups
-        number_of_selected_groups = query.count()
+        status = kwargs.get("status", "ACTIVE")
 
-        # Aggregation for total number of groups
-        total_number_of_groups = Group.objects.filter(is_deleted=False).count()
-        groups_not_assigned_to_programme = query.\
+        enrollment_checks = service.run_enrollment_checks(
+            custom_filters,
+            benefit_plan_id,
+            status,
+            user
+        )
+        
+        total_number_of_groups = enrollment_checks["total_number_of_groups"]
+        selected_groups = enrollment_checks["group_query_with_filters"]
+        num_assigned_to_selected_programme = enrollment_checks["groups_assigned_to_selected_programme"].count()
+
+        number_of_groups_assigned_to_selected_programme_and_status = enrollment_checks["num_groups_assigned_to_selected_programme_and_status"]
+        number_of_groups_to_upload = enrollment_checks["num_groups_to_enroll"]
+        max_active_beneficiaries_exceeded = enrollment_checks["max_active_beneficiaries_exceeded"]
+
+        number_of_selected_groups = selected_groups.count()
+
+        num_groups_not_assigned_to_programme = selected_groups.\
             filter(is_deleted=False, groupbeneficiary__benefit_plan_id__isnull=True).count()
-        groups_assigned_to_programme = number_of_selected_groups - groups_not_assigned_to_programme
-
-        groups_assigned_to_selected_programme = "0"
-        number_of_groups_to_upload = number_of_selected_groups
-        if benefit_plan_id:
-            groups_assigned_to_selected_programme = query. \
-                filter(is_deleted=False, groupbeneficiary__benefit_plan_id=benefit_plan_id).count()
-            number_of_groups_to_upload = number_of_groups_to_upload - groups_assigned_to_selected_programme
+        num_groups_assigned_to_programme = number_of_selected_groups - num_groups_not_assigned_to_programme
 
         return GroupSummaryEnrollmentGQLType(
             number_of_selected_groups=number_of_selected_groups,
             total_number_of_groups=total_number_of_groups,
-            number_of_groups_not_assigned_to_programme=groups_not_assigned_to_programme,
-            number_of_groups_assigned_to_programme=groups_assigned_to_programme,
-            number_of_groups_assigned_to_selected_programme=groups_assigned_to_selected_programme,
-            number_of_groups_to_upload=number_of_groups_to_upload
+            number_of_groups_not_assigned_to_programme=num_groups_not_assigned_to_programme,
+            number_of_groups_assigned_to_programme=num_groups_assigned_to_programme,
+            number_of_groups_assigned_to_selected_programme=num_assigned_to_selected_programme,
+            number_of_groups_assigned_to_selected_programme_and_status=number_of_groups_assigned_to_selected_programme_and_status,
+            number_of_groups_to_upload=number_of_groups_to_upload,
+            max_active_beneficiaries_exceeded=max_active_beneficiaries_exceeded,
         )
 
     def resolve_global_schema(self, info):

--- a/individual/services.py
+++ b/individual/services.py
@@ -114,7 +114,7 @@ class IndividualService(BaseService, UpdateCheckerLogicServiceMixin, DeleteCheck
             benefit_plan = BenefitPlan.objects.get(id=benefit_plan_id)
             max_active_beneficiaries = benefit_plan.max_beneficiaries
 
-            if max_active_beneficiaries:
+            if max_active_beneficiaries is not None:
                 prospective_active_beneficiaries = num_individuals_to_enroll + num_individuals_assigned_to_selected_programme_and_status
                 max_active_beneficiaries_exceeded = prospective_active_beneficiaries > max_active_beneficiaries
 
@@ -331,7 +331,7 @@ class GroupService(
             benefit_plan = BenefitPlan.objects.get(id=benefit_plan_id)
             max_active_beneficiaries = benefit_plan.max_beneficiaries
 
-            if max_active_beneficiaries:
+            if max_active_beneficiaries is not None:
                 prospective_active_beneficiaries = num_groups_to_enroll + num_groups_assigned_to_selected_programme_and_status
                 max_active_beneficiaries_exceeded = prospective_active_beneficiaries > max_active_beneficiaries
 

--- a/individual/tests/__init__.py
+++ b/individual/tests/__init__.py
@@ -5,3 +5,4 @@ from .group_individual_service_test import GroupIndividualServiceTest
 from .graphql_query_test import IndividualGQLQueryTest
 from .graphql_mutation_individual_test import IndividualGQLMutationTest
 from .graphql_mutation_group_test import GroupGQLMutationTest
+from .graphql_enrollment_test import EnrollmentGQLTest

--- a/individual/tests/graphql_enrollment_test.py
+++ b/individual/tests/graphql_enrollment_test.py
@@ -1,0 +1,234 @@
+import json
+from dataclasses import dataclass
+from django.utils.translation import gettext as _
+from core.services import wait_for_mutation
+
+from individual.models import Individual
+from individual.tests.test_helpers import (
+    create_individual,
+    create_group,
+    add_individual_to_group,
+    IndividualGQLTestCase,
+)
+
+from social_protection.tests.test_helpers import (
+    create_benefit_plan,
+    add_individual_to_benefit_plan,
+    add_group_to_benefit_plan,
+)
+from social_protection.models import BenefitPlan
+from social_protection.apps import SocialProtectionConfig
+from social_protection.services import BeneficiaryService, GroupBeneficiaryService
+
+class EnrollmentGQLTest(IndividualGQLTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.benef_service = BeneficiaryService(cls.admin_user)
+        cls.group_benef_service = GroupBeneficiaryService(cls.admin_user)
+
+        def create_individual_with_params(name, num_children, able_bodied=None): 
+            return create_individual(cls.admin_user.username, payload_override={
+                'first_name': name,
+                'json_ext': {
+                    'number_of_children': num_children,
+                    **({'able_bodied': able_bodied if able_bodied else {}})
+                }
+            })
+        
+        def create_group_with_params(name, num_children, able_bodied=None):
+            group = create_group(cls.admin_user.username)
+            for i in range(num_children + 1):
+                ind = create_individual_with_params(name, num_children, able_bodied)
+                add_individual_to_group(cls.admin_user.username, ind, group, is_head=i==0)
+            return group
+        
+        def add_to_benefit_plan(plan, status="POTENTIAL", benefs=[]):
+            for benef in benefs:
+                if plan.type == "INDIVIDUAL":
+                    add_individual_to_benefit_plan(cls.benef_service, benef, plan, payload_override={'status': status})
+                else:
+                    add_group_to_benefit_plan(cls.group_benef_service, benef, plan, payload_override={'status': status})
+
+        cls.benefit_plan_indiv = create_benefit_plan(cls.admin_user.username, payload_override={
+            'code': 'SGQLBase', 'type': "INDIVIDUAL"
+        })
+
+        cls.benefit_plan_indiv_max_active_benefs = create_benefit_plan(cls.admin_user.username, payload_override={
+            'code': 'SQGLMax', 'type': "INDIVIDUAL", 'max_beneficiaries': 2
+        })
+
+        cls.benefit_plan_group = create_benefit_plan(cls.admin_user.username, payload_override={
+            'code': 'GGQLBase', 'type': "GROUP"
+        })
+
+        cls.benefit_plan_group_max_active_benefs = create_benefit_plan(cls.admin_user.username, payload_override={
+            'code': 'GQGLMax', 'type': "GROUP", 'max_beneficiaries': 2
+        })
+
+        cls.individual_2child = create_individual_with_params('TwoChildren', 2)
+        cls.individual_1child = create_individual_with_params('OneChild', 1)
+        cls.individual_able_bodied =  create_individual_with_params('OneChild Able bodied', 1, able_bodied=True)
+        cls.individual =  create_individual_with_params('NoChild', 0)
+
+        cls.group_2child = create_group_with_params('TwoChildren', 2)
+        cls.group_1child = create_group_with_params('OneChild', 1)
+        cls.group_able_bodied =  create_group_with_params('OneChild Able bodied', 1, able_bodied=True)
+        cls.group =  create_group_with_params('NoChild', 0)
+
+        add_to_benefit_plan(cls.benefit_plan_indiv, status="POTENTIAL", benefs=[cls.individual_able_bodied, cls.individual_1child])
+        add_to_benefit_plan(cls.benefit_plan_indiv, status="ACTIVE", benefs=[cls.individual_2child])
+
+        add_to_benefit_plan(cls.benefit_plan_indiv_max_active_benefs, status="POTENTIAL", benefs=[cls.individual_2child])
+        add_to_benefit_plan(cls.benefit_plan_indiv_max_active_benefs, status="ACTIVE", benefs=[cls.individual_1child])
+
+        add_to_benefit_plan(cls.benefit_plan_group, status="POTENTIAL", benefs=[cls.group_able_bodied, cls.group_1child])
+        add_to_benefit_plan(cls.benefit_plan_group, status="ACTIVE", benefs=[cls.group_2child])
+
+        add_to_benefit_plan(cls.benefit_plan_group_max_active_benefs, status="POTENTIAL", benefs=[cls.group_2child])
+        add_to_benefit_plan(cls.benefit_plan_group_max_active_benefs, status="ACTIVE", benefs=[cls.group_1child])
+        
+
+        # EXPECTED OUTPUT (assumes individuals cannot be part of groups)
+        # total, selected, any_plan, no_plan, selected_plan, all_plan_status, to_enroll, max_active_benefs_exceeded
+        cls.ENROLLMENT_SUMMARY_KEYS = [
+            "totalNumberOfIndividuals",
+            "numberOfSelectedIndividuals",
+            "numberOfIndividualsAssignedToProgramme",
+            "numberOfIndividualsNotAssignedToProgramme",
+            "numberOfIndividualsAssignedToSelectedProgramme",
+            "numberOfIndividualsAssignedToSelectedProgrammeAndStatus",
+            "numberOfIndividualsToUpload",
+            "maxActiveBeneficiariesExceeded",
+        ]
+
+        cls.GROUP_ENROLLMENT_SUMMARY_KEYS = [
+            "totalNumberOfGroups",
+            "numberOfSelectedGroups",
+            "numberOfGroupsAssignedToProgramme",
+            "numberOfGroupsNotAssignedToProgramme",
+            "numberOfGroupsAssignedToSelectedProgramme",
+            "numberOfGroupsAssignedToSelectedProgrammeAndStatus",
+            "numberOfGroupsToUpload",
+            "maxActiveBeneficiariesExceeded",
+        ]
+
+        @dataclass
+        class EnrollmentTestCase:
+            benefit_plan: BenefitPlan
+            status: str
+            custom_filters: str
+            
+            @property
+            def is_group(self):
+                return self.benefit_plan.type == "GROUP"
+
+            def expect_summary(self, *args):
+                summary_keys = cls.GROUP_ENROLLMENT_SUMMARY_KEYS if self.is_group else cls.ENROLLMENT_SUMMARY_KEYS
+                self.expected_summary = dict(zip(summary_keys, args))
+                return self
+
+        total_ind = 12
+        total_group = 4
+                
+        cls.individual_enrollment_cases = [
+            EnrollmentTestCase(cls.benefit_plan_indiv_max_active_benefs, "ACTIVE", '[]').expect_summary(
+                total_ind, 4, 3, 1, 2, 1, 2, True  # Active, exceeds limit
+            ),
+            EnrollmentTestCase(cls.benefit_plan_indiv, "POTENTIAL", "[]").expect_summary(
+                total_ind, 4, 3, 1, 3, 2, 1, False  # Basic, those in group not selected
+            ),
+            EnrollmentTestCase(cls.benefit_plan_indiv_max_active_benefs, "POTENTIAL", "[]").expect_summary(
+                total_ind, 4, 3, 1, 2, 1, 2, False  # Different plan check
+            ),
+            EnrollmentTestCase(cls.benefit_plan_indiv, "POTENTIAL", '["able_bodied__exact__boolean=True"]').expect_summary(
+                total_ind, 1, 1, 0, 1, 2, 0, False  # Filters shouldn't apply to 'numberOfIndividualsAssignedToSelectedProgrammeAndStatus'
+            ),
+            EnrollmentTestCase(cls.benefit_plan_indiv, "ACTIVE", '[]').expect_summary(
+                total_ind, 4, 3, 1, 3, 1, 1, False  # Active, no max benefs limit
+            ),
+            EnrollmentTestCase(cls.benefit_plan_indiv_max_active_benefs, "ACTIVE", '["number_of_children__gte__integer=1"]').expect_summary(
+                total_ind, 3, 3, 0, 2, 1, 1, False  # Active, filters, within limit
+            ),
+        ]
+
+        cls.group_enrollment_cases = [
+            EnrollmentTestCase(cls.benefit_plan_group_max_active_benefs, "ACTIVE", '[]').expect_summary(
+                total_group, 4, 3, 1, 2, 1, 2, True  # Active, exceeds limit
+            ),
+            EnrollmentTestCase(cls.benefit_plan_group, "POTENTIAL", "[]").expect_summary(
+                total_group, 4, 3, 1, 3, 2, 1, False  # Basic, those in group not selected
+            ),
+            EnrollmentTestCase(cls.benefit_plan_group_max_active_benefs, "POTENTIAL", "[]").expect_summary(
+                total_group, 4, 3, 1, 2, 1, 2, False  # Different plan check
+            ),
+            EnrollmentTestCase(cls.benefit_plan_group, "POTENTIAL", '["able_bodied__exact__boolean=True"]').expect_summary(
+                total_group, 1, 1, 0, 1, 2, 0, False  # Filters shouldn't apply to 'numberOfGroupsAssignedToSelectedProgrammeAndStatus'
+            ),
+            EnrollmentTestCase(cls.benefit_plan_group, "ACTIVE", '[]').expect_summary(
+                total_group, 4, 3, 1, 3, 1, 1, False  # Active, no max benefs limit
+            ),
+            EnrollmentTestCase(cls.benefit_plan_group_max_active_benefs, "ACTIVE", '["number_of_children__gte__integer=1"]').expect_summary(
+                total_group, 3, 3, 0, 2, 1, 1, False  # Active, filters, within limit
+            ),
+        ]
+  
+    def test_individual_enrollment_summary_query(self):
+        newline = "\n\t"
+        def send_individual_enrollment_summary_query(benefit_plan_id, status, custom_filters):
+            query_str = f'''query {{
+                individualEnrollmentSummary(
+                    benefitPlanId: "{benefit_plan_id}"
+                    status: "{status}"
+                    customFilters: {custom_filters}
+                ) {{
+                {newline.join(self.ENROLLMENT_SUMMARY_KEYS)}
+                }}
+            }}'''
+
+            return self.query(
+                query_str,
+                headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
+            )
+        
+        for i, case in enumerate(self.individual_enrollment_cases):
+            response = send_individual_enrollment_summary_query(case.benefit_plan.uuid, case.status, case.custom_filters)
+            self.assertResponseNoErrors(response)
+            summary = json.loads(response.content)['data']['individualEnrollmentSummary']
+            for (key, expected_val) in case.expected_summary.items():
+                self.assertTrue(key in summary.keys(), f"Expected summary to have key {key} but key not found")
+                self.assertTrue(
+                    summary[key] == expected_val,
+                    f'Expected test case {i} to have {key} value {expected_val}, but got {summary[key]}'
+                )
+
+    def test_group_enrollment_summary_query(self):
+        newline = "\n\t"
+        def send_group_enrollment_summary_query(benefit_plan_id, status, custom_filters):
+            query_str = f'''query {{
+                groupEnrollmentSummary(
+                    benefitPlanId: "{benefit_plan_id}"
+                    status: "{status}"
+                    customFilters: {custom_filters}
+                ) {{
+                {newline.join(self.GROUP_ENROLLMENT_SUMMARY_KEYS)}
+                }}
+            }}'''
+
+            return self.query(
+                query_str,
+                headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
+            )
+        
+        for i, case in enumerate(self.group_enrollment_cases):
+            response = send_group_enrollment_summary_query(case.benefit_plan.uuid, case.status, case.custom_filters)
+            self.assertResponseNoErrors(response)
+            summary = json.loads(response.content)['data']['groupEnrollmentSummary']
+            for (key, expected_val) in case.expected_summary.items():
+                self.assertTrue(key in summary.keys(), f"Expected summary to have key {key} but key not found")
+                self.assertTrue(
+                    summary[key] == expected_val,
+                    f'Expected test case {i} to have {key} value {expected_val}, but got {summary[key]}'
+                )

--- a/individual/tests/graphql_enrollment_test.py
+++ b/individual/tests/graphql_enrollment_test.py
@@ -53,7 +53,7 @@ class EnrollmentGQLTest(IndividualGQLTestCase):
                     add_group_to_benefit_plan(cls.group_benef_service, benef, plan, payload_override={'status': status})
 
         cls.benefit_plan_indiv = create_benefit_plan(cls.admin_user.username, payload_override={
-            'code': 'SGQLBase', 'type': "INDIVIDUAL"
+            'code': 'SGQLBase', 'type': "INDIVIDUAL", 'max_beneficiaries': None
         })
 
         cls.benefit_plan_indiv_max_active_benefs = create_benefit_plan(cls.admin_user.username, payload_override={
@@ -61,7 +61,7 @@ class EnrollmentGQLTest(IndividualGQLTestCase):
         })
 
         cls.benefit_plan_group = create_benefit_plan(cls.admin_user.username, payload_override={
-            'code': 'GGQLBase', 'type': "GROUP"
+            'code': 'GGQLBase', 'type': "GROUP", 'max_beneficiaries': None
         })
 
         cls.benefit_plan_group_max_active_benefs = create_benefit_plan(cls.admin_user.username, payload_override={
@@ -223,6 +223,7 @@ class EnrollmentGQLTest(IndividualGQLTestCase):
             )
         
         for i, case in enumerate(self.group_enrollment_cases):
+            print(case.benefit_plan.name, case.benefit_plan.max_beneficiaries)
             response = send_group_enrollment_summary_query(case.benefit_plan.uuid, case.status, case.custom_filters)
             self.assertResponseNoErrors(response)
             summary = json.loads(response.content)['data']['groupEnrollmentSummary']

--- a/individual/tests/individual_service_test.py
+++ b/individual/tests/individual_service_test.py
@@ -66,3 +66,5 @@ class IndividualServiceTest(TestCase):
         self.assertTrue(result.get('success', False), result.get('detail', "No details provided"))
         query = self.query_all.filter(uuid=uuid)
         self.assertEqual(query.count(), 0)
+    
+    # TODO test service.select_individuals_to_benefit_plan. To avoid circular dependency, all enrollment functions should be moved to openimis-be-social_protection_py first.

--- a/individual/tests/test_helpers.py
+++ b/individual/tests/test_helpers.py
@@ -178,10 +178,10 @@ class IndividualGQLTestCase(openIMISGraphQLTestCase):
 
             time.sleep(1)
 
-    def assert_mutation_error(self, uuid, expected_error):
+    def assert_mutation_error(self, uuid, expected_error, extra_info=""):
         mutation_result = self.get_mutation_result(uuid, self.admin_token, internal=True)
         mutation_error = mutation_result['data']['mutationLogs']['edges'][0]['node']['error']
-        self.assertIsNotNone(mutation_error, f"no error found when this was expected {expected_error}")
+        self.assertIsNotNone(mutation_error, f"no error found when this was expected {expected_error}. {extra_info}")
         self.assertTrue(expected_error in mutation_error, mutation_error)
 
     def assert_mutation_success(self, uuid):


### PR DESCRIPTION
This adds to (and depends on) https://github.com/openimis/openimis-be-social_protection_py/pull/104 by checking whether max_beneficiaries (max active beneficiaries) would be exceeded by an enrollment summary query, allowing the front-end to prevent enrollment in that case. Tests are added for the enrollment summary queries.