### PR TITLE
Feature & Fix: allow same upload file name, coerce location code as str, and improve dummy individual file generation command

### DIFF
--- a/individual/management/commands/fake_individuals.py
+++ b/individual/management/commands/fake_individuals.py
@@ -58,6 +58,18 @@ class Command(BaseCommand):
             type=str,
             help="Specify the username such that their permitted locations are assigned to individuals"
         )
+        parser.add_argument(
+            '--num-individuals',
+            type=int,
+            default=100,
+            help="Number of individuals to generate (default: 100)"
+        )
+        parser.add_argument(
+            '--num-groups',
+            type=int,
+            default=20,
+            help="Number of groups to generate (default: 20)"
+        )
 
     def handle(self, *args, **options):
         # Retrieves the user with the specified username
@@ -71,20 +83,26 @@ class Command(BaseCommand):
         permitted_locations = list(location_qs.filter(type='V', *filter_validity()))
 
         individuals = []  # List to store fake individuals
-        num_individuals = 100  # Total number of individuals to generate
-        num_households = 20  # Number of households/groups
+        num_individuals = options.get('num_individuals')
+        num_groups = options.get('num_groups')
 
         # Exclude the HEAD role from available choices to ensure only one head per group
         available_role_choices = [choice for choice in GroupIndividual.Role if choice != GroupIndividual.Role.HEAD]
 
+        base_count = num_individuals // num_groups
+        remainder = num_individuals % num_groups
+
         # Generate individuals for each household/group
-        for group_index in range(0, num_households):
-            group_code = generate_random_string()  # Unique code for the group
+        for group_index in range(0, num_groups):
+            group_code = generate_random_string()
             assign_location = random.choice([True, False])  # Randomly decide whether to assign a location
             location = random.choice(permitted_locations) if assign_location else None
 
+            # Add one extra individual to groups while distributing the remainder
+            group_size = base_count + (1 if group_index < remainder else 0)
+
             # Generate individuals for the current group
-            for i in range(num_individuals // num_households):
+            for i in range(group_size):
                 recipient_info = 1 if i == 0 else 0  # Mark the first individual as a recipient
                 individual_role = GroupIndividual.Role.HEAD if i == 0 else random.choice(available_role_choices)
                 individual = generate_fake_individual(group_code, recipient_info, individual_role, location)

--- a/individual/management/commands/fake_individuals.py
+++ b/individual/management/commands/fake_individuals.py
@@ -68,7 +68,11 @@ class Command(BaseCommand):
             '--num-groups',
             type=int,
             default=20,
-            help="Number of groups to generate (default: 20)"
+            help=(
+                "Number of groups to generate (default: 20). "
+                "If set to 0, individuals will be generated without group-related fields "
+                "(i.e., group_code, recipient_info, individual_role)."
+            )
         )
 
     def handle(self, *args, **options):
@@ -86,26 +90,36 @@ class Command(BaseCommand):
         num_individuals = options.get('num_individuals')
         num_groups = options.get('num_groups')
 
-        # Exclude the HEAD role from available choices to ensure only one head per group
-        available_role_choices = [choice for choice in GroupIndividual.Role if choice != GroupIndividual.Role.HEAD]
+        if num_groups > 0:
+            # Exclude the HEAD role from available choices to ensure only one head per group
+            available_role_choices = [choice for choice in GroupIndividual.Role if choice != GroupIndividual.Role.HEAD]
 
-        base_count = num_individuals // num_groups
-        remainder = num_individuals % num_groups
+            base_count = num_individuals // num_groups
+            remainder = num_individuals % num_groups
 
-        # Generate individuals for each household/group
-        for group_index in range(0, num_groups):
-            group_code = generate_random_string()
-            assign_location = random.choice([True, False])  # Randomly decide whether to assign a location
-            location = random.choice(permitted_locations) if assign_location else None
+            # Generate individuals for each household/group
+            for group_index in range(0, num_groups):
+                group_code = generate_random_string()
+                assign_location = random.choice([True] * 3 + [False])  # Randomly decide whether to assign a location
+                location = random.choice(permitted_locations) if assign_location else None
 
-            # Add one extra individual to groups while distributing the remainder
-            group_size = base_count + (1 if group_index < remainder else 0)
+                # Add one extra individual to groups while distributing the remainder
+                group_size = base_count + (1 if group_index < remainder else 0)
 
-            # Generate individuals for the current group
-            for i in range(group_size):
-                recipient_info = 1 if i == 0 else 0  # Mark the first individual as a recipient
-                individual_role = GroupIndividual.Role.HEAD if i == 0 else random.choice(available_role_choices)
-                individual = generate_fake_individual(group_code, recipient_info, individual_role, location)
+                # Generate individuals for the current group
+                for i in range(group_size):
+                    recipient_info = 1 if i == 0 else 0  # Mark the first individual as a recipient
+                    individual_role = GroupIndividual.Role.HEAD if i == 0 else random.choice(available_role_choices)
+                    individual = generate_fake_individual(group_code, recipient_info, individual_role, location)
+                    individuals.append(individual)
+        else:
+            for _ in range(num_individuals):
+                assign_location = random.choice([True] * 3 + [False])
+                location = random.choice(permitted_locations) if assign_location else None
+                individual = generate_fake_individual(group_code=None, recipient_info=None, individual_role=None, location=location)
+                # Remove group-specific fields
+                for field in ['group_code', 'recipient_info', 'individual_role']:
+                    individual.pop(field, None)
                 individuals.append(individual)
 
         # Write the generated individuals to a temporary CSV file

--- a/individual/management/commands/fake_individuals.py
+++ b/individual/management/commands/fake_individuals.py
@@ -1,4 +1,5 @@
 import csv
+import json
 from faker import Faker
 from datetime import datetime, timedelta
 import random
@@ -6,37 +7,29 @@ import json
 import tempfile
 
 from django.core.management.base import BaseCommand
+from individual.apps import IndividualConfig
 from individual.models import GroupIndividual
 from individual.tests.test_helpers import generate_random_string
 from location.models import Location
 from core import filter_validity
 from core.models import User
 
-# Initializes a Faker instance for generating random data
 fake = Faker()
+individual_schema = json.loads(IndividualConfig.individual_schema)['properties']
 
-# Defines a JSON schema for the fake individual data structure
-json_schema = {
-    "email": {"type": "string"},
-    "able_bodied": {"type": "boolean"},
-    "national_id": {"type": "string"},
-    "educated_level": {"type": "string"},
-    "chronic_illness": {"type": "boolean"},
-    "national_id_type": {"type": "string"},
-    "number_of_elderly": {"type": "integer"},
-    "number_of_children": {"type": "integer"},
-    "beneficiary_data_source": {"type": "string"}
-}
-
-# Function to generate a fake individual with random data
 def generate_fake_individual(group_code, recipient_info, individual_role, location=None):
-    return {
+    required_info =  {
         "first_name": fake.first_name(),
         "last_name": fake.last_name(),
         "dob": fake.date_of_birth(minimum_age=16, maximum_age=90).isoformat(),
         "group_code": group_code,
         "recipient_info": recipient_info,
         "individual_role": individual_role,
+        "location_name": location.name if location else "",
+        "location_code": location.code if location else "",
+    }
+
+    others = {
         "email": fake.email(),
         "able_bodied": fake.boolean(),
         "national_id": fake.unique.ssn(),
@@ -46,15 +39,19 @@ def generate_fake_individual(group_code, recipient_info, individual_role, locati
         "number_of_elderly": fake.random_int(min=0, max=5),
         "number_of_children": fake.random_int(min=0, max=10),
         "beneficiary_data_source": fake.company(),
-        "location_name": location.name if location else "",
-        "location_code": location.code if location else "",
+    }
+
+    allowed_fields = set(individual_schema.keys())
+
+    return {
+        **required_info,
+        **{k: v for k, v in others.items() if k in allowed_fields}
     }
 
 # Django management command to create a CSV file with fake individuals
 class Command(BaseCommand):
     help = "Create test individual csv for uploading"
 
-    # Adds a command-line argument to specify the username
     def add_arguments(self, parser):
         parser.add_argument(
             '--username',
@@ -62,7 +59,6 @@ class Command(BaseCommand):
             help="Specify the username such that their permitted locations are assigned to individuals"
         )
 
-    # Main logic of the command
     def handle(self, *args, **options):
         # Retrieves the user with the specified username
         username = options.get('username')
@@ -97,9 +93,8 @@ class Command(BaseCommand):
         # Write the generated individuals to a temporary CSV file
         with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv', newline='') as tmp_file:
             writer = csv.DictWriter(tmp_file, fieldnames=list(individuals[0].keys()))
-            writer.writeheader()  # Write the CSV header
+            writer.writeheader()
             for individual in individuals:
-                writer.writerow(individual)  # Write each individual to the CSV file
+                writer.writerow(individual)
 
-            # Print a success message with the path to the generated file
             self.stdout.write(self.style.SUCCESS(f'Successfully created {num_individuals} fake individuals csv at {tmp_file.name}'))

--- a/individual/services.py
+++ b/individual/services.py
@@ -543,7 +543,7 @@ class GroupAndGroupIndividualAlignmentService:
 class IndividualImportService:
     import_loaders = {
         # .csv
-        'text/csv': lambda f: pd.read_csv(f),
+        'text/csv': lambda f: pd.read_csv(f, dtype={"location_code": str}),
         # .xlsx
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': lambda f: pd.read_excel(f),
         # .xls

--- a/individual/tests/individual_import_service_test.py
+++ b/individual/tests/individual_import_service_test.py
@@ -330,6 +330,21 @@ class IndividualImportServiceTest(TestCase):
                 "because there are more than one location with this name and code found in the system."
             )
 
+    def test_csv_location_code_parsed_as_string(self):
+        uploaded_csv_name = f"{generate_random_string(12)}.csv"
+        csv_file = SimpleUploadedFile(
+            uploaded_csv_name,
+            self.csv_content,
+            content_type="text/csv"
+        )
+
+        service = IndividualImportService(self.admin_user)
+        df = service._load_import_file(csv_file)
+
+        self.assertIn('location_code', df.columns)
+        self.assertEqual(df['location_code'].dtype, object)  # object dtype means it's read as string
+        self.assertEqual(df['location_code'].iloc[0], '202')
+
     @patch.object(BaseSyncDocument, 'update')
     def test_synchronize_data_for_reporting(self, mock_update):
         service = IndividualImportService(self.admin_user)

--- a/individual/tests/test_view.py
+++ b/individual/tests/test_view.py
@@ -2,9 +2,13 @@ import os
 from unittest.mock import patch, MagicMock
 from rest_framework.test import APITestCase
 from rest_framework import status
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.files.storage import default_storage
 from django.urls import reverse
+from django.utils import timezone
 from core.test_helpers import create_test_interactive_user
 from core.models import ModuleConfiguration
+from individual.apps import IndividualConfig
 
 
 class TestView(APITestCase):
@@ -19,12 +23,18 @@ class TestView(APITestCase):
         )
 
     def setUp(self):
+        self.download_url = reverse('download_template_file')
+        self.upload_url = reverse('import_individuals')
+        self.upload_data = {
+            'workflow_name': 'Test Workflow',
+            'workflow_group': 'Test Group',
+            'group_aggregation_column': 'group_code'
+        }
         self.admin_user = create_test_interactive_user()
+        self.client.force_authenticate(user=self.admin_user)
 
     def test_download_template_file(self):
-        self.client.force_authenticate(user=self.admin_user)
-        url = reverse('download_template_file')
-        response = self.client.get(url)
+        response = self.client.get(self.download_url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response['Content-Type'], 'text/csv')
@@ -54,9 +64,7 @@ class TestView(APITestCase):
             config.config = test_file.read()
         config.save()
 
-        self.client.force_authenticate(user=self.admin_user)
-        url = reverse('download_template_file')
-        response = self.client.get(url)
+        response = self.client.get(self.download_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Check the template file contains individual schema fields from fixture config
@@ -72,8 +80,6 @@ class TestView(APITestCase):
     @patch('individual.views.DefaultStorageFileHandler')
     def test_import_individuals_success(
             self, mock_file_handler, mock_individual_import_service, mock_workflow_service):
-
-        self.client.force_authenticate(user=self.admin_user)
 
         mock_workflow_service.get_workflows.return_value = {
             'success': True,
@@ -93,13 +99,8 @@ class TestView(APITestCase):
 
         with open(self.test_file_path, 'rb') as test_file:
             response = self.client.post(
-                reverse('import_individuals'),
-                data={
-                    'file': test_file,
-                    'workflow_name': 'Test Workflow',
-                    'workflow_group': 'Test Group',
-                    'group_aggregation_column': 'group_code'
-                },
+                self.upload_url,
+                data={**self.upload_data, 'file': test_file},
                 format='multipart'
             )
 
@@ -109,13 +110,78 @@ class TestView(APITestCase):
 
         mock_handler_instance.save_file.assert_called_once()
 
+    @patch('individual.views.WorkflowService.get_workflows')
+    @patch('individual.views.IndividualImportService.import_individuals')
+    def test_import_individuals_upload_same_file_twice_triggers_rename(
+        self, mock_import_service, mock_get_workflows
+    ):
+        mock_import_service.return_value = {'success': True}
+        mock_get_workflows.return_value = {
+            'success': True,
+            'data': {
+                'workflows': [{'id': 1, 'name': 'Test Workflow'}]
+            }
+        }
+
+        test_file_name = "test_individuals.csv"
+        dir_path = os.path.dirname(IndividualConfig.get_individual_upload_file_path(test_file_name))
+        for filename in default_storage.listdir(dir_path)[1]:  # files only
+            path = os.path.join(dir_path, filename)
+            if default_storage.exists(path):
+                default_storage.delete(path)
+
+        with open(self.test_file_path, 'rb') as test_file:
+            upload_content = test_file.read()
+
+        # First upload, freeze time at T0
+        with patch("individual.views.timezone.now") as mock_now:
+            mock_now.return_value = timezone.datetime(2025, 9, 11, 12, 0, 0)
+            first_upload = SimpleUploadedFile(
+                test_file_name,
+                upload_content,
+                content_type='text/csv'
+            )
+
+            response1 = self.client.post(
+                self.upload_url,
+                data={**self.upload_data, 'file': first_upload},
+                format='multipart'
+            )
+            self.assertEqual(response1.status_code, status.HTTP_200_OK)
+
+        first_path = IndividualConfig.get_individual_upload_file_path(test_file_name)
+        self.assertTrue(default_storage.exists(first_path))
+
+        # Second upload, tick time forward by +1 second (same filename, should be renamed automatically)
+        with patch("individual.views.timezone.now") as mock_now:
+            mock_now.return_value = timezone.datetime(2025, 9, 11, 12, 0, 1)
+            second_upload = SimpleUploadedFile(
+                name=test_file_name,
+                content=upload_content,
+                content_type='text/csv'
+            )
+
+            response2 = self.client.post(
+                self.upload_url,
+                data={**self.upload_data, 'file': second_upload},
+                format='multipart'
+            )
+            self.assertEqual(response2.status_code, status.HTTP_200_OK)
+
+        # Check that the renamed file exists and matches the expected suffix pattern
+        renamed_files = [
+            f for f in default_storage.listdir(os.path.dirname(
+                IndividualConfig.get_individual_upload_file_path(test_file_name)))[1]
+            if f.startswith("test_individuals_") and f.endswith(".csv")
+        ]
+        self.assertEqual(len(renamed_files), 1)
+        self.assertRegex(renamed_files[0], r"^test_individuals_\d{14}\.csv$")
+
     @patch('individual.views.WorkflowService')
     @patch('individual.views.IndividualImportService')
     @patch('individual.views.DefaultStorageFileHandler')
     def test_import_individuals_import_service_failure(
             self, mock_file_handler, mock_individual_import_service, mock_workflow_service):
-
-        self.client.force_authenticate(user=self.admin_user)
 
         mock_handler_instance = MagicMock()
         mock_file_handler.return_value = mock_handler_instance
@@ -135,13 +201,8 @@ class TestView(APITestCase):
 
         with open(self.test_file_path, 'rb') as test_file:
             response = self.client.post(
-                reverse('import_individuals'),
-                data={
-                    'file': test_file,
-                    'workflow_name': 'Test Workflow',
-                    'workflow_group': 'Test Group',
-                    'group_aggregation_column': 'group_code'
-                },
+                self.upload_url,
+                data={**self.upload_data, 'file': test_file},
                 format='multipart'
             )
 
@@ -157,8 +218,6 @@ class TestView(APITestCase):
     def test_import_individuals_workflow_service_failure(
             self, mock_file_handler, mock_workflow_service):
 
-        self.client.force_authenticate(user=self.admin_user)
-
         mock_handler_instance = MagicMock()
         mock_file_handler.return_value = mock_handler_instance
 
@@ -170,13 +229,8 @@ class TestView(APITestCase):
 
         with open(self.test_file_path, 'rb') as test_file:
             response = self.client.post(
-                reverse('import_individuals'),
-                data={
-                    'file': test_file,
-                    'workflow_name': 'Test Workflow',
-                    'workflow_group': 'Test Group',
-                    'group_aggregation_column': 'group_code'
-                },
+                self.upload_url,
+                data={**self.upload_data, 'file': test_file},
                 format='multipart'
             )
 

--- a/individual/tests/test_view.py
+++ b/individual/tests/test_view.py
@@ -125,10 +125,11 @@ class TestView(APITestCase):
 
         test_file_name = "test_individuals.csv"
         dir_path = os.path.dirname(IndividualConfig.get_individual_upload_file_path(test_file_name))
-        for filename in default_storage.listdir(dir_path)[1]:  # files only
-            path = os.path.join(dir_path, filename)
-            if default_storage.exists(path):
-                default_storage.delete(path)
+        if default_storage.exists(dir_path):
+            for filename in default_storage.listdir(dir_path)[1]:  # files only
+                path = os.path.join(dir_path, filename)
+                if default_storage.exists(path):
+                    default_storage.delete(path)
 
         with open(self.test_file_path, 'rb') as test_file:
             upload_content = test_file.read()

--- a/individual/views.py
+++ b/individual/views.py
@@ -6,7 +6,9 @@ import os
 import numpy as np
 import pandas as pd
 from django.db.models import Q
+from django.core.files.storage import default_storage
 from django.http import StreamingHttpResponse
+from django.utils import timezone
 from django.utils.translation import gettext as _
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -202,12 +204,18 @@ def download_individual_upload(request):
 
 # Function to handle file uploads and save them to a specified path
 def _handle_file_upload(file):
-    try:
-        target_file_path = IndividualConfig.get_individual_upload_file_path(file.name)
-        file_handler = DefaultStorageFileHandler(target_file_path)
-        file_handler.save_file(file)
-    except FileExistsError as exc:
-        raise exc
+    original_name = file.name
+    target_file_path = IndividualConfig.get_individual_upload_file_path(original_name)
+
+    if default_storage.exists(target_file_path):
+        base_name, ext = os.path.splitext(original_name)
+        timestamp = timezone.now().strftime('%Y%m%d%H%M%S')
+        unique_name = f"{base_name}_{timestamp}{ext}"
+        target_file_path = IndividualConfig.get_individual_upload_file_path(unique_name)
+        file.name = unique_name
+
+    file_handler = DefaultStorageFileHandler(target_file_path)
+    file_handler.save_file(file)
 
 # Function to remove a file from storage
 def _remove_file(file):


### PR DESCRIPTION
The PR has several fixes and enhancements to the individual import workflow:
- Current if the file with the same name is used for individual import uploading, the system will reject it with an error. I've made it automatically rename uploaded file on name conflict. Unit test added in `test_view.py`.
- There's a bug with the individual import in handling numeric location codes which can be parsed as float by pandas when using `pd.read_csv`. This may cause some records fail to be imported due to location lookup failure as the code is first treated as float e.g. 12345678.0 which later gets converted to `12345678.0' and would not match '12345678'. The fix has a regression test in `individual_import_service_test.py`.
- Also added the following enhancements to individual dummy data generation command fake_individual:
  - Make fake individuals generation script respect json schema
  - Allow number of individuals and groups to be specified as args of the command (e.g. `--num-individuals=20 --num-groups=5`)
  - Allow individuals to be generated without group fields when —-num-groups=0

It would be good to ship these bug fixes and enhancements with the upcoming release @zikani03 