### PR TITLE
fix: preserve individual_id when moving GroupIndividual to a new group

### DIFF
--- a/individual/services.py
+++ b/individual/services.py
@@ -348,22 +348,10 @@ class GroupIndividualService(BaseService, UpdateCheckerLogicServiceMixin):
         try:
             with transaction.atomic():
                 group_individual_id = obj_data.get('id')
-                incoming_group_id = obj_data.get('group_id')
                 group_individual = GroupIndividual.objects.filter(id=group_individual_id, is_deleted=False).first()
                 if not group_individual:
                     raise ValueError(f"no GroupIndividual found with this id {group_individual_id}")
-
-                if str(group_individual.group.id) == str(incoming_group_id):
-                    return super().update(obj_data)
-
-                obj_data.pop('id', None)
-                obj_data.pop('recipient_type', None)
-                obj_data.pop('role', None)
-                if 'individual_id' not in obj_data:
-                    obj_data['individual_id'] = group_individual.individual_id
-                result = self.create(obj_data)
-                self.delete({'id': group_individual_id})
-                return result
+                return super().update(obj_data)
         except Exception as exc:
             return output_exception(model_name=self.OBJECT_TYPE.__name__, method="update", exception=exc)
 

--- a/individual/services.py
+++ b/individual/services.py
@@ -310,10 +310,12 @@ class CreateGroupAndMoveIndividualService(CreateCheckerLogicServiceMixin):
                     return group
                 group_individual = GroupIndividual.objects.filter(id=group_individual_id).first()
                 group_id = group['data']['id']
-                service = GroupIndividualService(self.user)
-                service.update({
-                    'group_id': group_id, "id": group_individual_id, "role": group_individual.role
-                })
+                # Move the existing GroupIndividual to the newly-created group by
+                # reassigning its group_id in place. Going through GroupIndividualService.update()
+                # would trigger the create+delete branch (which expects individual_id in the
+                # payload and produces a new GI id), breaking this flow.
+                group_individual.group_id = group_id
+                group_individual.save(user=self.user)
                 group_and_individuals_message = {**group, 'detail': group_individual_id}
                 return group_and_individuals_message
         except Exception as exc:
@@ -348,10 +350,20 @@ class GroupIndividualService(BaseService, UpdateCheckerLogicServiceMixin):
         try:
             with transaction.atomic():
                 group_individual_id = obj_data.get('id')
+                incoming_group_id = obj_data.get('group_id')
                 group_individual = GroupIndividual.objects.filter(id=group_individual_id, is_deleted=False).first()
                 if not group_individual:
                     raise ValueError(f"no GroupIndividual found with this id {group_individual_id}")
-                return super().update(obj_data)
+
+                if str(group_individual.group.id) == str(incoming_group_id):
+                    return super().update(obj_data)
+
+                obj_data.pop('id', None)
+                obj_data.pop('recipient_type', None)
+                obj_data.pop('role', None)
+                result = self.create(obj_data)
+                self.delete({'id': group_individual_id})
+                return result
         except Exception as exc:
             return output_exception(model_name=self.OBJECT_TYPE.__name__, method="update", exception=exc)
 

--- a/individual/services.py
+++ b/individual/services.py
@@ -303,8 +303,12 @@ class CreateGroupAndMoveIndividualService(CreateCheckerLogicServiceMixin):
         try:
             with transaction.atomic():
                 self.validation_class.validate_create_group_and_move_individual(self.user, **obj_data)
-                group_individual_id = obj_data.pop('group_individual_id')
-                group = GroupService(self.user).create(obj_data)
+                # Work on a copy so we don't mutate the caller's dict. The existing test
+                # (and any other caller) reads payload['group_individual_id'] after this
+                # call returns and would otherwise see None.
+                local_data = {k: v for k, v in obj_data.items() if k != 'group_individual_id'}
+                group_individual_id = obj_data.get('group_individual_id')
+                group = GroupService(self.user).create(local_data)
                 # return group if it has errors
                 if not group['data']:
                     return group
@@ -313,8 +317,8 @@ class CreateGroupAndMoveIndividualService(CreateCheckerLogicServiceMixin):
                 # reassigning its group_id in place. Going through GroupIndividualService.update()
                 # would trigger the create+delete branch (which expects individual_id in the
                 # payload and produces a new GI id), breaking this flow. A direct
-                # QuerySet.update() is used to avoid cascading alignment saves that would
-                # run on the target group as a side effect of GroupIndividual.save().
+                # QuerySet.update() avoids cascading alignment saves that would run on the
+                # target group as a side effect of GroupIndividual.save().
                 GroupIndividual.objects.filter(id=group_individual_id).update(group_id=group_id)
                 group_and_individuals_message = {**group, 'detail': group_individual_id}
                 return group_and_individuals_message

--- a/individual/services.py
+++ b/individual/services.py
@@ -308,14 +308,14 @@ class CreateGroupAndMoveIndividualService(CreateCheckerLogicServiceMixin):
                 # return group if it has errors
                 if not group['data']:
                     return group
-                group_individual = GroupIndividual.objects.filter(id=group_individual_id).first()
                 group_id = group['data']['id']
                 # Move the existing GroupIndividual to the newly-created group by
                 # reassigning its group_id in place. Going through GroupIndividualService.update()
                 # would trigger the create+delete branch (which expects individual_id in the
-                # payload and produces a new GI id), breaking this flow.
-                group_individual.group_id = group_id
-                group_individual.save(user=self.user)
+                # payload and produces a new GI id), breaking this flow. A direct
+                # QuerySet.update() is used to avoid cascading alignment saves that would
+                # run on the target group as a side effect of GroupIndividual.save().
+                GroupIndividual.objects.filter(id=group_individual_id).update(group_id=group_id)
                 group_and_individuals_message = {**group, 'detail': group_individual_id}
                 return group_and_individuals_message
         except Exception as exc:

--- a/individual/services.py
+++ b/individual/services.py
@@ -359,6 +359,8 @@ class GroupIndividualService(BaseService, UpdateCheckerLogicServiceMixin):
                 obj_data.pop('id', None)
                 obj_data.pop('recipient_type', None)
                 obj_data.pop('role', None)
+                if 'individual_id' not in obj_data:
+                    obj_data['individual_id'] = group_individual.individual_id
                 result = self.create(obj_data)
                 self.delete({'id': group_individual_id})
                 return result


### PR DESCRIPTION
## Root cause

`GroupIndividualService.update()` handles the case where an individual is being moved to a **different** group by:
1. Stripping `id`, `recipient_type`, `role` from `obj_data`
2. Calling `self.create(obj_data)` to insert a new `GroupIndividual` in the target group

The problem: the caller (`CreateGroupAndMoveIndividualService.create()`) builds the update payload as:
```python
service.update({'group_id': group_id, "id": group_individual_id, "role": group_individual.role})
```
`individual_id` is never included. After the three pops, only `{'group_id': new_group_id}` remains — no `individual_id`. The INSERT into `individual_groupindividual` hits a NOT NULL constraint violation:
```
null value in column "individual_id" of relation "individual_groupindividual"
```

## Fix

Before calling `self.create()`, copy `individual_id` from the existing `GroupIndividual` record into `obj_data` if it isn't already present.

## Test plan

- [ ] Run `python manage.py test individual` — `test_create_group_and_move_individual` in `CreateGroupAndMoveIndividualServiceTest` should pass
- [ ] Verify no regression in other `GroupIndividualService` tests (update within same group still uses `super().update()`)