### PR TITLE
Let CSV import tasks follow multi-step approval flows

### DIFF
--- a/individual/signals/on_validation_import_valid_items.py
+++ b/individual/signals/on_validation_import_valid_items.py
@@ -296,6 +296,23 @@ def on_task_complete_action(business_event, **kwargs):
     upload_record = None
     try:
         upload_record = IndividualDataUploadRecords.objects.get(id=task['entity_id'])
+
+        # A task that followed an approval flow accumulated its per-record
+        # verdicts across every step. Drop what was rejected before running
+        # the workflow, so the import proceeds with the surviving rows - the
+        # same shape as the flat path, where a rejected row is soft-deleted
+        # and whatever remains is imported.
+        task_obj = Task.objects.filter(id=task['id']).first()
+        if task_obj and task_obj.flow_id:
+            from tasks_management.signals import flow_rejected_record_ids
+            rejected = flow_rejected_record_ids(task_obj)
+            if rejected:
+                logger.info(
+                    "individual.flow: dropping %s record(s) rejected during the "
+                    "approval flow of task %s", len(rejected), task_obj.id,
+                )
+                _delete_rejected(list(rejected), task_obj.source)
+
         if business_event == IndividualConfig.validation_import_valid_items:
             workflow = IndividualConfig.validation_import_valid_items_workflow
             IndividualItemsImportTaskCompletionEvent(
@@ -441,6 +458,14 @@ def on_task_resolve(**kwargs):
 
             # Task only relevant for this specific source
             if task.source != 'import_valid_items' and task.source != 'import_group_valid_items':
+                return
+
+            # A task following an approval flow is resolved by
+            # tasks_management's batch path: each vote is recorded per record
+            # against the current step, and the surviving set is applied once
+            # at completion. Resolving here as well would run the import on
+            # the first vote, bypassing every later step.
+            if task.flow_id:
                 return
 
             if not task.task_group:

--- a/individual/signals/on_validation_import_valid_items.py
+++ b/individual/signals/on_validation_import_valid_items.py
@@ -296,22 +296,34 @@ def on_task_complete_action(business_event, **kwargs):
     upload_record = None
     try:
         upload_record = IndividualDataUploadRecords.objects.get(id=task['entity_id'])
+        completion_user = User.objects.get(id=data['user']['id'])
 
         # A task that followed an approval flow accumulated its per-record
-        # verdicts across every step. Drop what was rejected before running
-        # the workflow, so the import proceeds with the surviving rows - the
-        # same shape as the flat path, where a rejected row is soft-deleted
-        # and whatever remains is imported.
+        # verdicts across every step. accepted=None below means "no filter,
+        # process the whole upload" (both the SQL workflows and
+        # group_data_sources_into_entities already support this) - a flow
+        # task instead passes the surviving ids explicitly, which every one
+        # of those paths already knows how to honour. This is the same
+        # existing mechanism a manual re-run with a hand-picked id list would
+        # use, not a new filter bolted on afterwards.
+        accepted_ids = None
         task_obj = Task.objects.filter(id=task['id']).first()
         if task_obj and task_obj.flow_id:
             from tasks_management.signals import flow_rejected_record_ids
             rejected = flow_rejected_record_ids(task_obj)
-            if rejected:
-                logger.info(
-                    "individual.flow: dropping %s record(s) rejected during the "
-                    "approval flow of task %s", len(rejected), task_obj.id,
-                )
-                _delete_rejected(list(rejected), task_obj.source)
+            upload_id = upload_record.data_upload.id
+            if business_event == IndividualConfig.validation_import_group_valid_items:
+                universe = set(str(i) for i in GroupDataSource.objects.filter(
+                    upload_id=upload_id, is_deleted=False).values_list('id', flat=True))
+            else:
+                universe = set(str(i) for i in IndividualDataSource.objects.filter(
+                    upload_id=upload_id, is_deleted=False).values_list('id', flat=True))
+            accepted_ids = list(universe - rejected)
+            logger.info(
+                "individual.flow: task %s completion restricted to %s surviving "
+                "record(s) of %s (%s rejected during the approval flow)",
+                task_obj.id, len(accepted_ids), len(universe), len(rejected),
+            )
 
         if business_event == IndividualConfig.validation_import_valid_items:
             workflow = IndividualConfig.validation_import_valid_items_workflow
@@ -319,7 +331,8 @@ def on_task_complete_action(business_event, **kwargs):
                 workflow,
                 upload_record,
                 upload_record.data_upload.id,
-                User.objects.get(id=data['user']['id'])
+                completion_user,
+                accepted_ids,
             ).run_workflow()
         elif business_event == IndividualConfig.validation_upload_valid_items:
             workflow = IndividualConfig.validation_upload_valid_items_workflow
@@ -327,11 +340,12 @@ def on_task_complete_action(business_event, **kwargs):
                 workflow,
                 upload_record,
                 upload_record.data_upload.id,
-                User.objects.get(id=data['user']['id'])
+                completion_user,
+                accepted_ids,
             ).run_workflow()
         elif business_event == IndividualConfig.validation_import_group_valid_items:
             BaseGroupColumnAggregationClass.group_data_sources_into_entities(
-                upload_record.data_upload.id, User.objects.get(id=data['user']['id'])
+                upload_record.data_upload.id, completion_user, accepted_ids,
             )
         else:
             raise ValueError(f"Business event {business_event} doesn't have assigned workflow.")

--- a/individual/tests/test_flow_batch_completion.py
+++ b/individual/tests/test_flow_batch_completion.py
@@ -17,11 +17,13 @@ from django.test import TestCase
 from core.test_helpers import create_test_interactive_user
 from individual.apps import IndividualConfig
 from individual.models import (
+    GroupDataSource,
     IndividualDataSource,
     IndividualDataSourceUpload,
     IndividualDataUploadRecords,
 )
 from individual.signals.on_validation_import_valid_items import (
+    BaseGroupColumnAggregationClass,
     IndividualItemsImportTaskCompletionEvent,
 )
 from tasks_management.apps import TasksManagementConfig
@@ -67,18 +69,31 @@ class FlowBatchCompletionTestCase(TestCase):
             sources.append(source)
         return upload_record, sources
 
-    def _flow_task(self, flow, step, upload_record):
+    def _flow_task(self, flow, step, upload_record, source='import_valid_items',
+                   business_event=None):
         task = Task(
-            source='import_valid_items',
+            source=source,
             entity=upload_record,
             status=Task.Status.ACCEPTED,
             executor_action_event=TasksManagementConfig.default_executor_event,
-            business_event=IndividualConfig.validation_import_valid_items,
+            business_event=business_event or IndividualConfig.validation_import_valid_items,
             business_status={}, data={},
             flow=flow, current_step=step, task_group=step.task_group,
         )
         task.save(username=self.admin.username)
         return task
+
+    def _group_upload_with_sources(self, record_count):
+        upload = IndividualDataSourceUpload(source_name='fbc_group_test', source_type='csv')
+        upload.save(username=self.admin.username)
+        upload_record = IndividualDataUploadRecords(data_upload=upload, workflow='fbc_group')
+        upload_record.save(username=self.admin.username)
+        sources = []
+        for i in range(record_count):
+            source = GroupDataSource(upload=upload, json_ext={'group_code': f'grp{i}'})
+            source.save(username=self.admin.username)
+            sources.append(source)
+        return upload_record, sources
 
     def _vote(self, task, user, verdict):
         return TaskService(user).resolve_task({
@@ -135,6 +150,47 @@ class FlowBatchCompletionTestCase(TestCase):
 
         self.assertEqual(len(captured), 1)
         accepted_ids = set(captured[0].accepted)
+        self.assertEqual(accepted_ids, {str(sources[2].id)})
+        self.assertNotIn(str(sources[0].id), accepted_ids)
+        self.assertNotIn(str(sources[1].id), accepted_ids)
+
+    def test_group_completion_receives_only_surviving_records(self):
+        """
+        Same cumulative-rejection guarantee for import_group_valid_items,
+        whose completion handler (group_data_sources_into_entities) has no
+        is_deleted filter of its own and previously relied on the caller
+        soft-deleting rejected rows - it now relies on the accepted list
+        instead.
+        """
+        flow, step1, step2 = self._two_step_flow('FBC_GROUP_FINAL')
+        upload_record, sources = self._group_upload_with_sources(3)
+        task = self._flow_task(
+            flow, step1, upload_record, source='import_group_valid_items',
+            business_event=IndividualConfig.validation_import_group_valid_items,
+        )
+
+        result = self._vote(task, self.exec_a, {
+            'ACCEPT': [str(sources[1].id), str(sources[2].id)],
+            'REJECT': [str(sources[0].id)],
+        })
+        self.assertTrue(result.get('success'), result)
+        task.refresh_from_db()
+        self.assertEqual(task.current_step_id, step2.id)
+
+        with patch.object(
+            BaseGroupColumnAggregationClass, 'group_data_sources_into_entities',
+        ) as mock_aggregate:
+            result = self._vote(task, self.exec_b, {
+                'ACCEPT': [str(sources[2].id)],
+                'REJECT': [str(sources[1].id)],
+            })
+            self.assertTrue(result.get('success'), result)
+            task.refresh_from_db()
+            self.assertEqual(task.status, Task.Status.COMPLETED)
+            mock_aggregate.assert_called_once()
+
+        _, call_args, _ = mock_aggregate.mock_calls[0]
+        accepted_ids = set(call_args[-1])
         self.assertEqual(accepted_ids, {str(sources[2].id)})
         self.assertNotIn(str(sources[0].id), accepted_ids)
         self.assertNotIn(str(sources[1].id), accepted_ids)

--- a/individual/tests/test_flow_batch_completion.py
+++ b/individual/tests/test_flow_batch_completion.py
@@ -1,0 +1,140 @@
+"""
+Signal-level coverage for CSV import tasks following a multi-step approval
+flow (openimis-be-tasks_management_py#72). Proves two properties raised in
+review: an intermediate vote must not run the import workflow, and the
+workflow that eventually runs must see only the records that survived every
+step - not the ones rejected along the way.
+
+The workflow's own SQL procedure is mocked out (autospec, capturing `self`)
+so these tests exercise the real signal dispatch chain - TaskService.resolve_task
+-> tasks_management's flow resolver -> this module's on_task_resolve /
+on_task_complete_action - without needing the underlying stored procedures.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from core.test_helpers import create_test_interactive_user
+from individual.apps import IndividualConfig
+from individual.models import (
+    IndividualDataSource,
+    IndividualDataSourceUpload,
+    IndividualDataUploadRecords,
+)
+from individual.signals.on_validation_import_valid_items import (
+    IndividualItemsImportTaskCompletionEvent,
+)
+from tasks_management.apps import TasksManagementConfig
+from tasks_management.models import Task, TaskExecutor, TaskFlow, TaskFlowStep, TaskGroup
+from tasks_management.services import TaskService
+
+
+class FlowBatchCompletionTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = create_test_interactive_user(username="fbc_admin")
+        cls.exec_a = create_test_interactive_user(username="fbc_exec_a")
+        cls.exec_b = create_test_interactive_user(username="fbc_exec_b")
+
+    def _group(self, code, executors):
+        group = TaskGroup(code=code, completion_policy='ANY')
+        group.save(username=self.admin.username)
+        for user in executors:
+            TaskExecutor(task_group=group, user=user).save(username=self.admin.username)
+        return group
+
+    def _two_step_flow(self, code):
+        group1 = self._group(f'{code}_g1', [self.exec_a])
+        group2 = self._group(f'{code}_g2', [self.exec_b])
+        flow = TaskFlow(code=code, name=code)
+        flow.save(username=self.admin.username)
+        step1 = TaskFlowStep(flow=flow, task_group=group1, order=1)
+        step1.save(username=self.admin.username)
+        step2 = TaskFlowStep(flow=flow, task_group=group2, order=2)
+        step2.save(username=self.admin.username)
+        return flow, step1, step2
+
+    def _upload_with_sources(self, record_count):
+        upload = IndividualDataSourceUpload(source_name='fbc_test', source_type='csv')
+        upload.save(username=self.admin.username)
+        upload_record = IndividualDataUploadRecords(data_upload=upload, workflow='fbc')
+        upload_record.save(username=self.admin.username)
+        sources = []
+        for i in range(record_count):
+            source = IndividualDataSource(upload=upload, json_ext={'first_name': f'row{i}'})
+            source.save(username=self.admin.username)
+            sources.append(source)
+        return upload_record, sources
+
+    def _flow_task(self, flow, step, upload_record):
+        task = Task(
+            source='import_valid_items',
+            entity=upload_record,
+            status=Task.Status.ACCEPTED,
+            executor_action_event=TasksManagementConfig.default_executor_event,
+            business_event=IndividualConfig.validation_import_valid_items,
+            business_status={}, data={},
+            flow=flow, current_step=step, task_group=step.task_group,
+        )
+        task.save(username=self.admin.username)
+        return task
+
+    def _vote(self, task, user, verdict):
+        return TaskService(user).resolve_task({
+            'id': task.id, 'business_status': {str(user.id): verdict},
+        })
+
+    def test_intermediate_vote_does_not_run_workflow(self):
+        flow, step1, step2 = self._two_step_flow('FBC_MID')
+        upload_record, sources = self._upload_with_sources(3)
+        task = self._flow_task(flow, step1, upload_record)
+
+        with patch.object(
+            IndividualItemsImportTaskCompletionEvent, 'run_workflow', autospec=True,
+        ) as mock_run:
+            result = self._vote(task, self.exec_a, {'ACCEPT': [str(sources[0].id)]})
+            self.assertTrue(result.get('success'), result)
+            task.refresh_from_db()
+            self.assertEqual(task.status, Task.Status.ACCEPTED)
+            mock_run.assert_not_called()
+
+    def test_completion_receives_only_surviving_records(self):
+        flow, step1, step2 = self._two_step_flow('FBC_FINAL')
+        upload_record, sources = self._upload_with_sources(3)
+        task = self._flow_task(flow, step1, upload_record)
+
+        # step 1: reject source[0], accept the rest
+        result = self._vote(task, self.exec_a, {
+            'ACCEPT': [str(sources[1].id), str(sources[2].id)],
+            'REJECT': [str(sources[0].id)],
+        })
+        self.assertTrue(result.get('success'), result)
+        task.refresh_from_db()
+        self.assertEqual(task.status, Task.Status.ACCEPTED)
+        self.assertEqual(task.current_step_id, step2.id)
+
+        captured = []
+
+        def fake_run_workflow(self):
+            captured.append(self)
+
+        with patch.object(
+            IndividualItemsImportTaskCompletionEvent, 'run_workflow',
+            autospec=True, side_effect=fake_run_workflow,
+        ) as mock_run:
+            # step 2: reject source[1] too - cumulative across both steps
+            result = self._vote(task, self.exec_b, {
+                'ACCEPT': [str(sources[2].id)],
+                'REJECT': [str(sources[1].id)],
+            })
+            self.assertTrue(result.get('success'), result)
+            task.refresh_from_db()
+            self.assertEqual(task.status, Task.Status.COMPLETED)
+            mock_run.assert_called_once()
+
+        self.assertEqual(len(captured), 1)
+        accepted_ids = set(captured[0].accepted)
+        self.assertEqual(accepted_ids, {str(sources[2].id)})
+        self.assertNotIn(str(sources[0].id), accepted_ids)
+        self.assertNotIn(str(sources[1].id), accepted_ids)


### PR DESCRIPTION
# Description

Lets CSV import validation tasks (`import_valid_items`, `import_group_valid_items`) follow a multi-step approval flow instead of being resolved on the first vote.

Requires openimis/openimis-be-tasks_management_py#71, which carries the batch approval path this depends on.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)

N/A

---

## Changes

- `on_task_resolve` stands down for a task that follows a flow. `tasks_management` records that reviewer's per-record verdicts against the current step and advances the batch; resolving here as well would run the import on the first vote and bypass every later step.
- `on_task_complete_action` drops the rows rejected at any step before running the import workflow, so the import proceeds with the survivors.

---

## Behaviour Before / After

| | Before | After |
|---|---|---|
| Import task on a flow | not possible — the source was flow-ineligible | advances step by step, each step filtering rows |
| Accepted rows | imported on the first reviewer's vote | imported once, after the final step |
| Rejected rows | soft-deleted at the vote that rejected them | soft-deleted; the rejection holds for the rest of the flow |

Behaviour without a flow is unchanged: `task.flow_id` is null and every existing path runs exactly as before.

---

## Key decisions

**The business action moves to completion time, not per vote.** This is what made the feature possible: applying the import per vote is precisely what bypassed later steps. The completion handler already ran the workflow over the whole upload, so the change is to subtract the rejected rows rather than to invent a new application path.

**Rejection stays a row-level outcome, not a task-level one.** A rejected row is dropped and the rest proceed, matching the existing flat behaviour rather than failing the whole batch.

## Next steps

- The task table still renders every row as actionable to a later-step reviewer. Rows rejected at an earlier step are visible in the tasks_management decisions panel but are not yet greyed out here.
- Reviewers of import tasks need this module's read rights in addition to the task rights, or the task page will not load for them.

## Demo

_To be added after manual verification._

## Checklist

- [x] Verified end to end on a live stack: a 3-row CSV through a 2-step flow, rejecting one row at each step, leaving exactly the surviving row imported
- [x] No migration required
